### PR TITLE
set timeout for remote jobs, and fix phonopy displacement generation

### DIFF
--- a/tests/test_phonopy.py
+++ b/tests/test_phonopy.py
@@ -21,10 +21,14 @@ def test_phonopy(tmp_path):
 
     pert = list(pert)
 
-    assert len(pert) == 1*2 + 6*2
+    # displaced + 1 phonon x 2 + 6 strain x 2
+    assert len(pert) == 1 + 1*2 + 6*2
 
-    for d, at in zip(displs, pert):
+    # first 3 configs should be undisplaced and 2 displaced magnitudes along (1 1 0)
+    for d, at in zip([0.0] + displs, pert[:3]):
+        # first atom displaced along (1 1 0)
         np.testing.assert_allclose(at.positions[0], [0.0, d/np.sqrt(2), d/np.sqrt(2)])
+        # all other atoms undisplaced
         for v in at.positions[1:]:
             assert min(np.linalg.norm(sc.positions[1:] - v, axis=1)) < 1.0e-7
 
@@ -42,16 +46,34 @@ def test_phono3py(tmp_path):
 
     pert = list(pert)
 
-    assert len(pert) == ((1 + 13 + 6) * 2 ) * 2
+    # (undisplaced fc2 and fc3 + (1 harmonic + 13 cubic + 6 strain) * 2 magnitudes) * 2 configs
+    assert len(pert) == 4 + ((1 + 13 + 6) * 2 ) * 2
     assert sum([at.info["config_type"] == "phonon_harmonic_0" for at in pert]) == 1*2
     assert sum([at.info["config_type"] == "phonon_harmonic_1" for at in pert]) == 1*2
     assert sum([at.info["config_type"] == "phonon_strain_0" for at in pert]) == 6*2
     assert sum([at.info["config_type"] == "phonon_strain_1" for at in pert]) == 6*2
 
     for at in pert:
-        if at.info["config_type"].startswith("phonon_harmonic_"):
+        if at.info["config_type"].startswith("phonon_harmonic_") and "undispl" not in at.info["config_type"]:
             di = int(at.info["config_type"].replace("phonon_harmonic_", ""))
             np.testing.assert_allclose(at.positions[0], [0.0, displs[di] / np.sqrt(2), displs[di] / np.sqrt(2)])
 
     assert sum([at.info["config_type"] == "phonon_cubic_0" for at in pert]) == 13*2
     assert sum([at.info["config_type"] == "phonon_cubic_1" for at in pert]) == 13*2
+
+
+def test_phono3py_same_supercell(tmp_path):
+    at0 = Atoms(numbers=[29], cell = [[0, 2, 2], [2, 0, 2], [2, 2, 0]], positions = [[0, 0, 0]], pbc = [True]*3)
+    at1 = Atoms(numbers=[29], cell = [[0, 1.9, 1.9], [1.9, 0, 1.9], [1.9, 1.9, 0]], positions = [[0, 0, 0]], pbc = [True]*3)
+
+    ci = ConfigSet_in(input_configs=[at0, at1])
+    co = ConfigSet_out(output_files=str(tmp_path / "phonopy_3.xyz"))
+
+    displs = [0.1, 0.2]
+    strain_displs = [0.05, 0.1]
+    pert = run(ci, co, displs, strain_displs, [2, 2, 2], [2, 2, 2], 3.0)
+
+    pert = list(pert)
+
+    # (undisplaced fc2 + (1 harmonic + 13 cubic + 6 strain) * 2 magnitudes) * 2 configs
+    assert len(pert) == 2 + ((1 + 13 + 6) * 2 ) * 2

--- a/wfl/cli/gap_rss_iter_fit.py
+++ b/wfl/cli/gap_rss_iter_fit.py
@@ -116,7 +116,7 @@ def print_log(msg, show_time=True, blank_lines=False, logfiles=[sys.stdout, sys.
         if blank_lines:
             logf.write('\n')
         for l in msg.splitlines():
-            logf.write('LOG' + time_str + ':' + l + '\n')
+            logf.write('LOG' + time_str + ': ' + l + '\n')
         if blank_lines:
             logf.write('\n')
         logf.flush()

--- a/wfl/fit/ace.py
+++ b/wfl/fit/ace.py
@@ -129,7 +129,7 @@ def fit(fitting_configs, ACE_name, params, ref_property_prefix='REF_',
 
         if not wait_for_results:
             return None
-        results, stdout, stderr = xpr.get_results()
+        results, stdout, stderr = xpr.get_results(timeout=remote_info.timeout, check_interval=remote_info.check_interval)
 
         sys.stdout.write(stdout)
         sys.stderr.write(stderr)

--- a/wfl/fit/gap_multistage.py
+++ b/wfl/fit/gap_multistage.py
@@ -169,10 +169,11 @@ def fit(fitting_configs, GAP_name, params, ref_property_prefix='REF_',
 
         fitting_configs = fitting_configs.in_memory()
 
-        # set number of threads in queued job
-        # NOTE: should this be hardwired here, or up to the user?
-        remote_info.env_vars.append('GAP_FIT_OMP_NUM_THREADS=$EXPYRE_NCORES_PER_NODE')
-        remote_info.env_vars.append('WFL_AUTOPARA_NPOOL=$EXPYRE_NCORES_PER_NODE')
+        # set number of threads in queued job, only if user hasn't set them
+        if not any([var.split('=')[0] == 'GAP_FIT_OMP_NUM_THREADS' for var in remote_info.env_vars]):
+            remote_info.env_vars.append('GAP_FIT_OMP_NUM_THREADS=$EXPYRE_NCORES_PER_NODE')
+        if not any([var.split('=')[0] == 'WFL_AUTOPARAL_NPOOL' for var in remote_info.env_vars]):
+            remote_info.env_vars.append('WFL_AUTOPARA_NPOOL=$EXPYRE_NCORES_PER_NODE')
 
         xpr = ExPyRe(name=remote_info.job_name, pre_run_commands=remote_info.pre_cmds, post_run_commands=remote_info.post_cmds,
                      env_vars=remote_info.env_vars, input_files=remote_info.input_files, output_files=output_files, function=fit,

--- a/wfl/fit/gap_multistage.py
+++ b/wfl/fit/gap_multistage.py
@@ -169,8 +169,11 @@ def fit(fitting_configs, GAP_name, params, ref_property_prefix='REF_',
             # Potential seems to return RuntimeError when file is missing
             pass
 
-    remote_info = to_RemoteInfo(remote_info, 'WFL_GAP_MULTISTAGE_FIT_REMOTEINFO')
-    if remote_info is not None and remote_info != '_IGNORE':
+    if remote_info == '_IGNORE':
+        remote_info = None
+    else:
+        remote_info = to_RemoteInfo(remote_info, 'WFL_GAP_MULTISTAGE_FIT_REMOTEINFO')
+    if remote_info is not None:
 
         input_files = remote_info.output_files.copy()
         output_files = remote_info.output_files.copy() + [str(run_dir)]
@@ -192,7 +195,7 @@ def fit(fitting_configs, GAP_name, params, ref_property_prefix='REF_',
 
         xpr.start(resources=remote_info.resources, system_name=remote_info.sys_name,
                   exact_fit=remote_info.exact_fit, partial_node=remote_info.partial_node)
-        results, stdout, stderr = xpr.get_results()
+        results, stdout, stderr = xpr.get_results(timeout=remote_info.timeout, check_interval=remote_info.check_interval)
         sys.stdout.write(stdout)
         sys.stderr.write(stderr)
 

--- a/wfl/fit/gap_simple.py
+++ b/wfl/fit/gap_simple.py
@@ -74,8 +74,7 @@ def run_gap_fit(fitting_configs, fitting_dict, stdout_file, gap_fit_exec="gap_fi
             output_files.append(use_stdout_file)
 
         # set number of threads in queued job, if user didn't already request a specific number
-        if all([not env_var == 'GAP_FIT_OMP_NUM_THREADS' and
-                not env_var.startswith('GAP_FIT_OMP_NUM_THREADS=') for env_var in remote_info.env_vars]):
+        if not any([var.split('=')[0] == 'GAP_FIT_OMP_NUM_THREADS' for var in remote_info.env_vars]):
             remote_info.env_vars.append('GAP_FIT_OMP_NUM_THREADS=$EXPYRE_NCORES_PER_NODE')
 
         remote_func_kwargs = {'fitting_configs': fitting_configs, 'fitting_dict': fitting_dict,

--- a/wfl/fit/gap_simple.py
+++ b/wfl/fit/gap_simple.py
@@ -88,7 +88,7 @@ def run_gap_fit(fitting_configs, fitting_dict, stdout_file, gap_fit_exec="gap_fi
 
         xpr.start(resources=remote_info.resources, system_name=remote_info.sys_name,
                   exact_fit=remote_info.exact_fit, partial_node=remote_info.partial_node)
-        results, stdout, stderr = xpr.get_results()
+        results, stdout, stderr = xpr.get_results(timeout=remote_info.timeout, check_interval=remote_info.check_interval)
         sys.stdout.write(stdout)
         sys.stderr.write(stderr)
 

--- a/wfl/fit/utils.py
+++ b/wfl/fit/utils.py
@@ -112,16 +112,33 @@ def copy_properties(configs, ref_property_keys, stress_to_virial=True, force=Tru
 
 
 def to_RemoteInfo(remote_info, env_var):
+    """create a RemoteInfo object out of input or env var
+
+    Parameters
+    ----------
+    remote_info: RemoteInfo or dict or str or None
+        input structure (just returned), dict used as kwargs for constructor, or string to be interpreted as JSON string or filename 
+    env_var: str
+        name of env var to be used if remote_info is None
+
+    Returns
+    -------
+    None or RemoteInfo
+    """
     if remote_info is None:
-        if env_var in os.environ:
-            try:
-                remote_info = json.loads(os.environ[env_var])
-            except:
-                with open(os.environ[env_var]) as fin:
-                    remote_info = json.load(fin)
-            remote_info = RemoteInfo(**remote_info)
+        # try to get default from env_var
+        remote_info = os.environ.get(env_var, None)
+
+    if isinstance(remote_info, str):
+        try:
+            remote_info = json.loads(remote_info)
+        except json.decoder.JSONDecodeError:
+            with open(remote_info) as fin:
+                remote_info = json.load(fin)
 
     if isinstance(remote_info, dict):
         remote_info = RemoteInfo(**remote_info)
+
+    assert remote_info is None or isinstance(remote_info, RemoteInfo)
 
     return remote_info

--- a/wfl/generate_configs/phonopy.py
+++ b/wfl/generate_configs/phonopy.py
@@ -73,29 +73,39 @@ def run_op(atoms, displacements, strain_displs, ph2_supercell, ph3_supercell=Non
         for displ_i, displ in enumerate(displacements):
             # need to create Phono[3]py inside loop since generate_displacements() is called once it cannot be
             # called again, apparently
-            if ph3_supercell is not None:
-                ph3 = phono3py.Phono3py(at_ph, supercell_matrix=ph3_sc_mat, phonon_supercell_matrix=ph2_sc_mat)
-            else:
+
+            d2 = []
+            d3 = []
+            if ph2_supercell is not None:
                 ph2 = phonopy.Phonopy(at_ph, ph2_sc_mat)
-
-            if ph3_supercell is not None:
-                ph3.generate_displacements(distance=displ, cutoff_pair_distance=pair_cutoff)
-                d2 = ph3.phonon_supercells_with_displacements
-                d3 = [a for a in ph3.supercells_with_displacements if a is not None]
-            else:
                 ph2.generate_displacements(distance=displ)
+                d2_undispl = ph2.supercell
                 d2 = ph2.supercells_with_displacements
-                d3 = []
+            if ph3_supercell is not None:
+                ph3 = phono3py.Phono3py(at_ph, supercell_matrix=ph3_sc_mat)
+                ph3.generate_displacements(distance=displ, cutoff_pair_distance=pair_cutoff)
+                d3_undispl = ph3.supercell
+                d3 = [a for a in ph3.supercells_with_displacements if a is not None]
 
-            for at in d2:
-                at_pert = Atoms(cell=at.cell, positions=at.positions, numbers=at.numbers, pbc=[True]*3)
-                at_pert.info["config_type"] = f"phonon_harmonic_{displ_i}"
-                ats_pert[-1].append(at_pert)
+            if len(d2) > 0:
+                if displ_i == 0:
+                    at_pert = Atoms(cell=d2_undispl.cell, positions=d2_undispl.positions, numbers=d2_undispl.numbers, pbc=[True]*3)
+                    at_pert.info["config_type"] = f"phonon_harmonic_undispl"
+                    ats_pert[-1].append(at_pert)
+                for at in d2:
+                    at_pert = Atoms(cell=at.cell, positions=at.positions, numbers=at.numbers, pbc=[True]*3)
+                    at_pert.info["config_type"] = f"phonon_harmonic_{displ_i}"
+                    ats_pert[-1].append(at_pert)
 
-            for at in d3:
-                at_pert = Atoms(cell=at.cell, positions=at.positions, numbers=at.numbers, pbc=[True]*3)
-                at_pert.info["config_type"] = f"phonon_cubic_{displ_i}"
-                ats_pert[-1].append(at_pert)
+            if len(d3) > 0:
+                if displ_i == 0:
+                    at_pert = Atoms(cell=d3_undispl.cell, positions=d3_undispl.positions, numbers=d3_undispl.numbers, pbc=[True]*3)
+                    at_pert.info["config_type"] = f"phonon_cubic_undispl"
+                    ats_pert[-1].append(at_pert)
+                for at in d3:
+                    at_pert = Atoms(cell=at.cell, positions=at.positions, numbers=at.numbers, pbc=[True]*3)
+                    at_pert.info["config_type"] = f"phonon_cubic_{displ_i}"
+                    ats_pert[-1].append(at_pert)
 
         for displ_i, displ in enumerate(strain_displs):
             for i0 in range(3):

--- a/wfl/pipeline/remote.py
+++ b/wfl/pipeline/remote.py
@@ -78,7 +78,7 @@ def do_remotely(remote_info, hash_ignore=[], chunksize=1, iterable=None, configs
     for xpr in xprs:
         if not quiet:
             sys.stderr.write(f'Gathering results for {xpr.id}\n')
-        ats_out, stdout, stderr = xpr.get_results(check_interval=remote_info.check_interval)
+        ats_out, stdout, stderr = xpr.get_results(timeout=remote_info.timeout, check_interval=remote_info.check_interval)
         for at in ats_out.group_iter():
             configset_out.write(at, from_input_file=input_files[at_i])
             at_i += 1

--- a/wfl/pipeline/utils.py
+++ b/wfl/pipeline/utils.py
@@ -12,9 +12,8 @@ class RemoteInfo:
         name for job (unique within this project)
     resources: dict or Resources
         expyre.resources.Resources or kwargs for its constructor
-    job_chunksize: int
-        chunksize for each job, default -100. If negative will be
-        multiplied by iterable_op chunksize
+    job_chunksize: int, default -100
+        chunksize for each job. If negative will be multiplied by iterable_op chunksize
     pre_cmds: list(str)
         commands to run before starting job
     post_cmds: list(str)
@@ -55,7 +54,7 @@ class RemoteInfo:
 
 
     def __str__(self):
-        return f'{self.sys_name} {self.job_name} {self.resources} {self.job_chunksize} {self.exact_fit} {self.partial_node}'
+        return f'{self.sys_name} {self.job_name} {self.resources} {self.job_chunksize} {self.exact_fit} {self.partial_node} {self.timeout} {self.check_interval}'
 
 
 def grouper(n, iterable):

--- a/wfl/pipeline/utils.py
+++ b/wfl/pipeline/utils.py
@@ -29,11 +29,13 @@ class RemoteInfo:
         require exact fit to node size
     partial_node: bool, default True
         allow jobs that take less than a whole node, overrides exact_fit
+    timeout: int
+        time to wait in get_results before giving up
     check_interval: int
         check_interval arg to pass to get_results
     """
     def __init__(self, sys_name, job_name, resources, job_chunksize=-100, pre_cmds=[], post_cmds=[],
-                 env_vars=[], input_files=[], output_files=[], exact_fit=True, partial_node=False, check_interval=30):
+                 env_vars=[], input_files=[], output_files=[], exact_fit=True, partial_node=False, timeout=3600, check_interval=30):
 
         self.sys_name = sys_name
         self.job_name = job_name
@@ -48,6 +50,7 @@ class RemoteInfo:
 
         self.exact_fit = exact_fit
         self.partial_node = partial_node
+        self.timeout = timeout
         self.check_interval = check_interval
 
 


### PR DESCRIPTION
Add support for passing timeout to `ExPyRe.get_results()`, rather than the hardwired default of 3600 s.  Also work around phono3py bug (perhaps now fixed in https://github.com/phonopy/phono3py/pull/65) by always using phonopy (rather than phono3py) for harmonic force constant (phonon) displacements.