### PR TITLE
Per remote job header

### DIFF
--- a/tests/calculators/test_qe.py
+++ b/tests/calculators/test_qe.py
@@ -40,7 +40,9 @@ def qe_cmd_and_pseudo(tmp_path_factory):
     else:
         cmd = which("pw.x")
 
-    url = "https://www.quantum-espresso.org/upf_files/Si.pbe-n-kjpaw_psl.1.0.0.UPF"
+    # broken due to need for account/license click
+    # url = "https://www.quantum-espresso.org/upf_files/Si.pbe-n-kjpaw_psl.1.0.0.UPF"
+    url = "http://nninc.cnf.cornell.edu/psp_files/Si.pz-vbc.UPF"
 
     # get the pseudo potential file, ~1.2MB
     try:
@@ -130,7 +132,7 @@ def test_qe_kpoints():
     assert kw["koffset"] == (0, 0, 0)
 
 
-@pytest.mark.xfail(reason="Hard-wired values are wrong, also calculation does not converge with default conv_thr")
+@pytest.mark.xfail(reason="PP file changes. Even before that hard-wired values are wrong, also calculation does not converge with default conv_thr")
 def test_qe_calculation(tmp_path, qe_cmd_and_pseudo):
     # command and pspot
     qe_cmd, pspot = qe_cmd_and_pseudo

--- a/wfl/pipeline/remote.py
+++ b/wfl/pipeline/remote.py
@@ -69,7 +69,7 @@ def do_remotely(remote_info, hash_ignore=[], chunksize=1, iterable=None, configs
     for xpr in xprs:
         if not quiet:
             sys.stderr.write(f'Starting job for {xpr.id}\n')
-        xpr.start(resources=remote_info.resources, system_name=remote_info.sys_name,
+        xpr.start(resources=remote_info.resources, system_name=remote_info.sys_name, header_extra=remote_info.header_extra,
                   exact_fit=remote_info.exact_fit, partial_node=remote_info.partial_node)
 
     # gather results and write them to original configset_out

--- a/wfl/pipeline/utils.py
+++ b/wfl/pipeline/utils.py
@@ -24,6 +24,8 @@ class RemoteInfo:
         input_files to stage in starting job
     output_files: list(str)
         output_files to stage out when job is done
+    header_extra: list(str), optional
+        extra lines to add to queuing system header
     exact_fit: bool, default True
         require exact fit to node size
     partial_node: bool, default True
@@ -34,7 +36,8 @@ class RemoteInfo:
         check_interval arg to pass to get_results
     """
     def __init__(self, sys_name, job_name, resources, job_chunksize=-100, pre_cmds=[], post_cmds=[],
-                 env_vars=[], input_files=[], output_files=[], exact_fit=True, partial_node=False, timeout=3600, check_interval=30):
+                 env_vars=[], input_files=[], output_files=[], header_extra=[],
+                 exact_fit=True, partial_node=False, timeout=3600, check_interval=30):
 
         self.sys_name = sys_name
         self.job_name = job_name
@@ -46,6 +49,7 @@ class RemoteInfo:
                          "OMP_NUM_THREADS=${EXPYRE_NCORES_PER_TASK}"] + env_vars
         self.input_files = input_files.copy()
         self.output_files = output_files.copy()
+        self.header_extra = header_extra.copy()
 
         self.exact_fit = exact_fit
         self.partial_node = partial_node


### PR DESCRIPTION
New field,  `header_extra`, in `RemoteInfo` structure, which is passed to `ExPyRe.start()`. 

Note that this PR is currently based on the ACE1 patch, which will therefore need to be merged first (or something will have to be rebased).