### PR TITLE
More places where header_extra needs to be passed.

### DIFF
--- a/wfl/fit/ace.py
+++ b/wfl/fit/ace.py
@@ -123,7 +123,7 @@ def fit(fitting_configs, ACE_name, params, ref_property_prefix='REF_',
                                'run_dir': str(run_dir), 'formats': formats, 'ace_fit_exec': ace_fit_exec,
                                'dry_run': dry_run, 'verbose': verbose, 'remote_info': '_IGNORE'})
 
-        xpr.start(resources=remote_info.resources, system_name=remote_info.sys_name,
+        xpr.start(resources=remote_info.resources, system_name=remote_info.sys_name, header_extra=remote_info.header_extra,
                   exact_fit=remote_info.exact_fit, partial_node=remote_info.partial_node)
 
         if not wait_for_results:

--- a/wfl/fit/gap_multistage.py
+++ b/wfl/fit/gap_multistage.py
@@ -190,7 +190,7 @@ def fit(fitting_configs, GAP_name, params, ref_property_prefix='REF_',
                              'num_committee': num_committee, 'committee_extra_seeds': committee_extra_seeds,
                              'committee_name_postfix': committee_name_postfix, 'verbose': verbose, 'remote_info': '_IGNORE'})
 
-        xpr.start(resources=remote_info.resources, system_name=remote_info.sys_name,
+        xpr.start(resources=remote_info.resources, system_name=remote_info.sys_name, header_extra=remote_info.header_extra,
                   exact_fit=remote_info.exact_fit, partial_node=remote_info.partial_node)
         results, stdout, stderr = xpr.get_results(timeout=remote_info.timeout, check_interval=remote_info.check_interval)
         sys.stdout.write(stdout)

--- a/wfl/fit/gap_simple.py
+++ b/wfl/fit/gap_simple.py
@@ -85,7 +85,7 @@ def run_gap_fit(fitting_configs, fitting_dict, stdout_file, gap_fit_exec="gap_fi
                       env_vars=remote_info.env_vars, input_files=input_files, output_files=output_files, function=run_gap_fit,
                       kwargs=remote_func_kwargs)
 
-        xpr.start(resources=remote_info.resources, system_name=remote_info.sys_name,
+        xpr.start(resources=remote_info.resources, system_name=remote_info.sys_name, header_extra=remote_info.header_extra,
                   exact_fit=remote_info.exact_fit, partial_node=remote_info.partial_node)
         results, stdout, stderr = xpr.get_results(timeout=remote_info.timeout, check_interval=remote_info.check_interval)
         sys.stdout.write(stdout)


### PR DESCRIPTION
Add header_extra to other calls to ExPyRe.start(), namely in `wfl/fit/{ace,gap}*py`.  Maybe this should be made more automatic somehow?