### PR TITLE
Make wfl cli CUR-global command able to calculate its own descriptors

### DIFF
--- a/wfl/cli/cli.py
+++ b/wfl/cli/cli.py
@@ -716,7 +716,7 @@ def _repeat_buildcell(ctx, output_file, output_all_or_none, buildcell_input, bui
 @click.option("--output-all-or-none", is_flag=True)
 @click.option("--n-configs", "-N", type=click.INT, required=True,
               help="number of configs to select")
-@click.option("--descriptor-key", type=click.STRING, help="Atoms.info key for descriptor vector", default="_CUR_desc")
+@click.option("--descriptor-key", type=click.STRING, help="Atoms.info key for descriptor vector")
 @click.option("--descriptor", type=click.STRING, help="quippy.Descriptor arg string")
 @click.option("--keep_descriptor", is_flag=True, help="keep the descriptor value in the final config file")
 @click.option("--kernel_exponent", type=click.FLOAT, help="exponent of dot-product for kernel")
@@ -725,8 +725,13 @@ def _repeat_buildcell(ctx, output_file, output_all_or_none, buildcell_input, bui
 def _CUR_global(ctx, inputs, output_file, output_all_or_none, n_configs,
                 descriptor_key, descriptor, keep_descriptor,
                 kernel_exponent, deterministic):
+    if descriptor is None:
+        if descriptor_key is None:
+            raise RuntimeError('CUR-global needs --descriptor or --descriptor-key')
     if descriptor is not None:
         # calculate descriptor
+        if descriptor_key is None:
+            descriptor_key = '_CUR_desc'
         _do_calc_descriptor(inputs, '_desc.xyz', output_all_or_none, descriptor, descriptor_key, False, True)
         inputs = '_desc.xyz'
 

--- a/wfl/cli/cli.py
+++ b/wfl/cli/cli.py
@@ -9,6 +9,7 @@ import os
 import sys
 import warnings
 from pprint import pformat, pprint
+from pathlib import Path
 
 import ase.data
 import ase.io
@@ -728,12 +729,14 @@ def _CUR_global(ctx, inputs, output_file, output_all_or_none, n_configs,
     if descriptor is None:
         if descriptor_key is None:
             raise RuntimeError('CUR-global needs --descriptor or --descriptor-key')
+    clean_tmp_files = False
     if descriptor is not None:
         # calculate descriptor
         if descriptor_key is None:
             descriptor_key = '_CUR_desc'
-        _do_calc_descriptor(inputs, '_desc.xyz', output_all_or_none, descriptor, descriptor_key, False, True)
-        inputs = '_desc.xyz'
+        _do_calc_descriptor(inputs, '_tmp_desc.xyz', output_all_or_none, descriptor, descriptor_key, local=False, force=True)
+        inputs = ['_tmp_desc.xyz']
+        clean_tmp_files = True
 
     wfl.select_configs.by_descriptor.CUR_conf_global(
         inputs=ConfigSet_in(input_files=inputs),
@@ -741,6 +744,10 @@ def _CUR_global(ctx, inputs, output_file, output_all_or_none, n_configs,
         num=n_configs,
         at_descs_info_key=descriptor_key, kernel_exp=kernel_exponent, stochastic=not deterministic,
         keep_descriptor_info=keep_descriptor)
+
+    if clean_tmp_files:
+        for input_file in inputs:
+            Path(input_file).unlink()
 
 
 @subcli_descriptor.command("calc")

--- a/wfl/cli/cli.py
+++ b/wfl/cli/cli.py
@@ -749,7 +749,7 @@ def _CUR_global(ctx, inputs, output_file, output_all_or_none, n_configs,
 @click.option("--local", is_flag=True, help="calculate a local (per-atom) descriptor")
 @click.option("--force", is_flag=True, help="overwrite existing info or arrays item if present")
 def _calc_descriptor(ctx, inputs, output_file, output_all_or_none, descriptor, key, local, force):
-    _do_calc_descriptor(inputs, output_file, all_or_none, descriptor, key, local, force)
+    _do_calc_descriptor(inputs, output_file, output_all_or_none, descriptor, key, local, force)
 
 
 def _do_calc_descriptor(inputs, output_file, output_all_or_none, descriptor, key, local, force):


### PR DESCRIPTION
Extract contents of cli descriptor calculation into its own non-decorated function, which can be called from the cli descriptor calc command, and also be optionally called from the cli command for doing selection with global CUR.