### PR TITLE
Fix scaling of energy_sigma, etc, when set by modify_database functions

### DIFF
--- a/wfl/fit/modify_database/gap_rss_set_config_sigmas_from_convex_hull.py
+++ b/wfl/fit/modify_database/gap_rss_set_config_sigmas_from_convex_hull.py
@@ -128,10 +128,14 @@ def modify(configs, overall_error_scale_factor=1.0, field_error_scale_factors=No
             sigma_E_1 = 0.001
             sigma_E_2 = 0.100
             sigma_set = piecewise_linear(dE,
-                                         [(0.1, [sigma_E_1, np.sqrt(sigma_E_1), 2.0 * np.sqrt(sigma_E_1),
-                                                 2.0 * np.sqrt(sigma_E_1)]),
-                                          (1.0, [sigma_E_2, np.sqrt(sigma_E_2), 2.0 * np.sqrt(sigma_E_2),
-                                                 2.0 * np.sqrt(sigma_E_2)])])
+                                         [(0.1, [len(at) * sigma_E_1,
+                                                 np.sqrt(sigma_E_1),
+                                                 len(at) * 2.0 * np.sqrt(sigma_E_1),
+                                                 len(at) * 2.0 * np.sqrt(sigma_E_1)]),
+                                          (1.0, [len(at) * sigma_E_2,
+                                                 np.sqrt(sigma_E_2),
+                                                 len(at) * 2.0 * np.sqrt(sigma_E_2),
+                                                 len(at) * 2.0 * np.sqrt(sigma_E_2)])])
             for (field_i, field) in enumerate(['energy_sigma', 'force_sigma', 'virial_sigma', 'hessian_sigma']):
                 if "fix_" + field in at.info:
                     sys.stdout.write(

--- a/wfl/fit/modify_database/gap_rss_set_config_sigmas_from_convex_hull.py
+++ b/wfl/fit/modify_database/gap_rss_set_config_sigmas_from_convex_hull.py
@@ -125,17 +125,22 @@ def modify(configs, overall_error_scale_factor=1.0, field_error_scale_factors=No
                     "WARNING: modifying sigmas based on distance from convex hull got a non-periodic config that "
                     "wasn't handled specially.  Skipping!")
                 continue
-            sigma_E_1 = 0.001
-            sigma_E_2 = 0.100
+            # energy, virial, and Hessian should be scaled by sqrt(N)
+            # add factors to keep relationship to previous, incorrect values that
+            #    ignored this scaling
+            root_characteristic_N = np.sqrt(16)
+            root_N = np.sqrt(len(at))
+            sigma_E_1 = 0.001 / root_characteristic_N
+            sigma_E_2 = 0.100 / root_characteristic_N
             sigma_set = piecewise_linear(dE,
-                                         [(0.1, [len(at) * sigma_E_1,
-                                                 np.sqrt(sigma_E_1),
-                                                 len(at) * 2.0 * np.sqrt(sigma_E_1),
-                                                 len(at) * 2.0 * np.sqrt(sigma_E_1)]),
-                                          (1.0, [len(at) * sigma_E_2,
-                                                 np.sqrt(sigma_E_2),
-                                                 len(at) * 2.0 * np.sqrt(sigma_E_2),
-                                                 len(at) * 2.0 * np.sqrt(sigma_E_2)])])
+                                         [(0.1, [root_N * sigma_E_1,
+                                                 np.sqrt(sigma_E_1 * root_characteristic_N),
+                                                 root_N * 2.0 * np.sqrt(sigma_E_1),
+                                                 root_N * 2.0 * np.sqrt(sigma_E_1)]),
+                                          (1.0, [root_N * sigma_E_2,
+                                                 np.sqrt(sigma_E_2 * root_characteristic_N),
+                                                 root_N * 2.0 * np.sqrt(sigma_E_2),
+                                                 root_N * 2.0 * np.sqrt(sigma_E_2)])])
             for (field_i, field) in enumerate(['energy_sigma', 'force_sigma', 'virial_sigma', 'hessian_sigma']):
                 if "fix_" + field in at.info:
                     sys.stdout.write(


### PR DESCRIPTION
Scale programmatically set energy, virial, and hessian sigmas by `len(at)`, as per #36.

WARNING: Will completely break backward compatibility of existing runs, since ratios between energy/force/virial sigmas will now be qualitatively different.

Closes #36 