### PR TITLE
Make calculators more robust to arbitrary ASE exceptions

### DIFF
--- a/wfl/calculators/castep.py
+++ b/wfl/calculators/castep.py
@@ -6,6 +6,7 @@ CASTEP calculator with functionality to use both MPI and multiprocessing
 import os
 import pathlib
 import tempfile
+import warnings
 
 from ase import Atoms
 from ase.calculators.calculator import CalculationFailed

--- a/wfl/calculators/castep.py
+++ b/wfl/calculators/castep.py
@@ -101,6 +101,8 @@ def evaluate_op(
         try:
             at.calc.calculate(at)
             calculation_succeeded = True
+            if 'DFT_FAILED_CASTEP' in at.info:
+                del at.info['DFT_FAILED_CASTEP']
         except Exception as exc:
             # TypeError needed here until https://gitlab.com/ase/ase/-/issues/912 is resolved
             warnings.warn(f'Calculation failed with exc {exc}')

--- a/wfl/calculators/castep.py
+++ b/wfl/calculators/castep.py
@@ -104,6 +104,7 @@ def evaluate_op(
         except Exception as exc:
             # TypeError needed here until https://gitlab.com/ase/ase/-/issues/912 is resolved
             warnings.warn(f'Calculation failed with exc {exc}')
+            at.info['DFT_FAILED_CASTEP'] = True
 
         if calculation_succeeded:
             # NOTE: this try catch should not be necessary, but ASE castep calculator does not

--- a/wfl/calculators/castep.py
+++ b/wfl/calculators/castep.py
@@ -100,9 +100,9 @@ def evaluate_op(
         try:
             at.calc.calculate(at)
             calculation_succeeded = True
-        except (CalculationFailed, TypeError):
+        except Exception as exc:
             # TypeError needed here until https://gitlab.com/ase/ase/-/issues/912 is resolved
-            pass
+            warnings.warn(f'Calculation failed with exc {exc}')
 
         if calculation_succeeded:
             # NOTE: this try catch should not be necessary, but ASE castep calculator does not

--- a/wfl/calculators/espresso.py
+++ b/wfl/calculators/espresso.py
@@ -111,6 +111,7 @@ def evaluate_op(
             # for failed convergence, Espresso currently returns subprocess.CalledProcessError
             #     since pw.x returns a non-zero status
             warnings.warn(f'Calculation failed with exc {exc}')
+            at.info['DFT_FAILED_ESPRESSO'] = True
 
         # save results
         if calculation_succeeded:

--- a/wfl/calculators/espresso.py
+++ b/wfl/calculators/espresso.py
@@ -106,12 +106,11 @@ def evaluate_op(
         try:
             at.calc.calculate(at, properties=properties_use, system_changes=all_changes)
             calculation_succeeded = True
-        except (CalculationFailed, subprocess.CalledProcessError) as exc:
+        except Exception as exc:
             # CalculationFailed is probably what's supposed to be returned
             # for failed convergence, Espresso currently returns subprocess.CalledProcessError
             #     since pw.x returns a non-zero status
             warnings.warn(f'Calculation failed with exc {exc}')
-            pass
 
         # save results
         if calculation_succeeded:

--- a/wfl/calculators/espresso.py
+++ b/wfl/calculators/espresso.py
@@ -106,6 +106,8 @@ def evaluate_op(
         try:
             at.calc.calculate(at, properties=properties_use, system_changes=all_changes)
             calculation_succeeded = True
+            if 'DFT_FAILED_ESPRESSO' in at.info:
+                del at.info['DFT_FAILED_ESPRESSO']
         except Exception as exc:
             # CalculationFailed is probably what's supposed to be returned
             # for failed convergence, Espresso currently returns subprocess.CalledProcessError

--- a/wfl/calculators/orca.py
+++ b/wfl/calculators/orca.py
@@ -172,8 +172,8 @@ def evaluate_op(atoms, base_rundir=None, dir_prefix="ORCA_",
         try:
             at.calc.calculate(at)
             calculation_succeeded = True
-        except CalculationFailed:
-            pass
+        except Exception as exc:
+            warnings.warn(f'Calculation failed with exc {exc}')
 
         if calculation_succeeded and not basin_hopping:
             # task='opt' in ExtendedORCA performs geometry optimisation,

--- a/wfl/calculators/orca.py
+++ b/wfl/calculators/orca.py
@@ -173,6 +173,8 @@ def evaluate_op(atoms, base_rundir=None, dir_prefix="ORCA_",
         try:
             at.calc.calculate(at)
             calculation_succeeded = True
+            if 'DFT_FAILED_ORCA' in at.info:
+                del at.info['DFT_FAILED_ORCA']
         except Exception as exc:
             warnings.warn(f'Calculation failed with exc {exc}')
             at.info['DFT_FAILED_ORCA'] = True

--- a/wfl/calculators/orca.py
+++ b/wfl/calculators/orca.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 import tempfile
 import traceback
+import warnings
 
 import ase.io
 import numpy as np

--- a/wfl/calculators/orca.py
+++ b/wfl/calculators/orca.py
@@ -175,6 +175,7 @@ def evaluate_op(atoms, base_rundir=None, dir_prefix="ORCA_",
             calculation_succeeded = True
         except Exception as exc:
             warnings.warn(f'Calculation failed with exc {exc}')
+            at.info['DFT_FAILED_ORCA'] = True
 
         if calculation_succeeded and not basin_hopping:
             # task='opt' in ExtendedORCA performs geometry optimisation,

--- a/wfl/calculators/vasp.py
+++ b/wfl/calculators/vasp.py
@@ -165,6 +165,8 @@ def evaluate_op(
         try:
             at.calc.calculate(at, properties_use)
             calculation_succeeded = True
+            if 'DFT_FAILED_VASP' in at.info:
+                del at.info['DFT_FAILED_VASP']
         except Exception as exc:
             warnings.warn(f"VASP calculation failed with exception {exc}")
             at.info['DFT_FAILED_VASP'] = True

--- a/wfl/calculators/vasp.py
+++ b/wfl/calculators/vasp.py
@@ -167,6 +167,7 @@ def evaluate_op(
             calculation_succeeded = True
         except Exception as exc:
             warnings.warn(f"VASP calculation failed with exception {exc}")
+            at.info['DFT_FAILED_VASP'] = True
 
         if calculation_succeeded:
             save_results(at, properties_use, output_prefix)


### PR DESCRIPTION
 CASTEP, Espresso, and ORCA calculators ignore _all_ exceptions n underlying ASE Calculator call, not just specific list.