### PR TITLE
Skip remote failures

### DIFF
--- a/wfl/calculators/castep.py
+++ b/wfl/calculators/castep.py
@@ -6,6 +6,7 @@ CASTEP calculator with functionality to use both MPI and multiprocessing
 import os
 import pathlib
 import tempfile
+import warnings
 
 from ase import Atoms
 from ase.calculators.calculator import CalculationFailed

--- a/wfl/calculators/castep.py
+++ b/wfl/calculators/castep.py
@@ -104,6 +104,7 @@ def evaluate_op(
         except Exception as exc:
             # TypeError needed here until https://gitlab.com/ase/ase/-/issues/912 is resolved
             warnings.warn(f'Calculation failed with exc {exc}')
+            at.info['DFT_FAILED_CASTEP'] = True
 
         if calculation_succeeded:
             # NOTE: this try catch should not be necessary, but ASE castep calculator does not

--- a/wfl/calculators/castep.py
+++ b/wfl/calculators/castep.py
@@ -100,9 +100,9 @@ def evaluate_op(
         try:
             at.calc.calculate(at)
             calculation_succeeded = True
-        except (CalculationFailed, TypeError):
+        except Exception as exc:
             # TypeError needed here until https://gitlab.com/ase/ase/-/issues/912 is resolved
-            pass
+            warnings.warn(f'Calculation failed with exc {exc}')
 
         if calculation_succeeded:
             # NOTE: this try catch should not be necessary, but ASE castep calculator does not

--- a/wfl/calculators/espresso.py
+++ b/wfl/calculators/espresso.py
@@ -111,6 +111,7 @@ def evaluate_op(
             # for failed convergence, Espresso currently returns subprocess.CalledProcessError
             #     since pw.x returns a non-zero status
             warnings.warn(f'Calculation failed with exc {exc}')
+            at.info['DFT_FAILED_ESPRESSO'] = True
 
         # save results
         if calculation_succeeded:

--- a/wfl/calculators/espresso.py
+++ b/wfl/calculators/espresso.py
@@ -106,12 +106,11 @@ def evaluate_op(
         try:
             at.calc.calculate(at, properties=properties_use, system_changes=all_changes)
             calculation_succeeded = True
-        except (CalculationFailed, subprocess.CalledProcessError) as exc:
+        except Exception as exc:
             # CalculationFailed is probably what's supposed to be returned
             # for failed convergence, Espresso currently returns subprocess.CalledProcessError
             #     since pw.x returns a non-zero status
             warnings.warn(f'Calculation failed with exc {exc}')
-            pass
 
         # save results
         if calculation_succeeded:

--- a/wfl/calculators/orca.py
+++ b/wfl/calculators/orca.py
@@ -172,8 +172,8 @@ def evaluate_op(atoms, base_rundir=None, dir_prefix="ORCA_",
         try:
             at.calc.calculate(at)
             calculation_succeeded = True
-        except CalculationFailed:
-            pass
+        except Exception as exc:
+            warnings.warn(f'Calculation failed with exc {exc}')
 
         if calculation_succeeded and not basin_hopping:
             # task='opt' in ExtendedORCA performs geometry optimisation,

--- a/wfl/calculators/orca.py
+++ b/wfl/calculators/orca.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 import tempfile
 import traceback
+import warnings
 
 import ase.io
 import numpy as np

--- a/wfl/calculators/orca.py
+++ b/wfl/calculators/orca.py
@@ -175,6 +175,7 @@ def evaluate_op(atoms, base_rundir=None, dir_prefix="ORCA_",
             calculation_succeeded = True
         except Exception as exc:
             warnings.warn(f'Calculation failed with exc {exc}')
+            at.info['DFT_FAILED_ORCA'] = True
 
         if calculation_succeeded and not basin_hopping:
             # task='opt' in ExtendedORCA performs geometry optimisation,

--- a/wfl/calculators/vasp.py
+++ b/wfl/calculators/vasp.py
@@ -167,6 +167,7 @@ def evaluate_op(
             calculation_succeeded = True
         except Exception as exc:
             warnings.warn(f"VASP calculation failed with exception {exc}")
+            at.info['DFT_FAILED_VASP'] = True
 
         if calculation_succeeded:
             save_results(at, properties_use, output_prefix)

--- a/wfl/pipeline/utils.py
+++ b/wfl/pipeline/utils.py
@@ -34,10 +34,13 @@ class RemoteInfo:
         time to wait in get_results before giving up
     check_interval: int
         check_interval arg to pass to get_results
+    skip_failures: bool, default False
+        skip failures in remote jobs
     """
     def __init__(self, sys_name, job_name, resources, job_chunksize=-100, pre_cmds=[], post_cmds=[],
                  env_vars=[], input_files=[], output_files=[], header_extra=[],
-                 exact_fit=True, partial_node=False, timeout=3600, check_interval=30):
+                 exact_fit=True, partial_node=False, timeout=3600, check_interval=30,
+                 skip_failures=False):
 
         self.sys_name = sys_name
         self.job_name = job_name
@@ -55,6 +58,7 @@ class RemoteInfo:
         self.partial_node = partial_node
         self.timeout = timeout
         self.check_interval = check_interval
+        self.skip_failures = skip_failures
 
 
     def __str__(self):


### PR DESCRIPTION
Skip failures in remote jobs, either re-outputting input configs or skipping (if input iterator is not of `Atoms` objects).

Putting @gelzinyte as reviewer since Ioan is not on the list (not a developer for this repo?)