### PR TITLE
Fix bug in remote job ACE fit

### DIFF
--- a/wfl/scripts/ace_fit.jl
+++ b/wfl/scripts/ace_fit.jl
@@ -34,6 +34,8 @@ function save_dry_run_info(fit_params)
 end
 
 if haskey(ENV, "ACE_FIT_BLAS_THREADS")
+    using LinearAlgebra
+
     nprocs = parse(Int, ENV["ACE_FIT_BLAS_THREADS"])
     @warn "Using $nprocs threads for BLAS"
     BLAS.set_num_threads(nprocs)


### PR DESCRIPTION
Current code converts fitting configs to list in `prepare_configs()`, but `run_ace_fit()` still tries to call the `to_memory()` method when preparing for a remote job.  PR removes the call to `to_memory()`, and documents that `run_ace_fit()` expects a _list_ of Atoms.

This would probably have been caught if we routinely ran the remote versions of the tests.