### PR TITLE
Fix encoding of dictionary-type gap_fit_params values for gap_fit commandline

### DIFF
--- a/tests/test_gap_fitting_simple.py
+++ b/tests/test_gap_fitting_simple.py
@@ -18,7 +18,7 @@ def test_dict_to_quip_str():
                        'delta': 1, 'covariance_type': 'dot_product',
                        'zeta': 4, 'n_sparse': 100,
                        'sparse_method': 'cur_points',
-                       'config_type_sigma': 'cfg1:1.0:2.0:0.3:4.0:cfg2:1:1:1:1',
+                       'config_type_sigma': { 'cfg1' : [1.0, 2.0, 0.3, 4.0], 'cfg2': [1, 1, 1, 1]},
                        'atom_gaussian_width': 0.3, 'add_species': False,
                        'n_species': 3, 'Z': 8, 'species_Z': [8, 1, 6]}
 

--- a/wfl/utils/quip_cli_strings.py
+++ b/wfl/utils/quip_cli_strings.py
@@ -21,6 +21,17 @@ def dict_to_quip_str(d, list_brackets='{}'):
 
     assert len(list_brackets) % 2 == 0
 
+    def _list_join(sep, v):
+        if isinstance(v, str):
+            # strings are iterable but need to be used as is
+            return v
+
+        try:
+            # try treating as an iterable
+            return sep.join([str(vv) for vv in v])
+        except TypeError as exc:
+            return v
+
     string = ''
     for key, val in d.items():
         if isinstance(val, list):
@@ -29,6 +40,8 @@ def dict_to_quip_str(d, list_brackets='{}'):
             string += f'{key}=' + (list_brackets[0:len(list_brackets) // 2] +
                                    ' '.join([str(v) for v in val]) +
                                    list_brackets[len(list_brackets) // 2:])
+        elif isinstance(val, dict):
+            string += f'{key}=' + ':'.join([k + ':' + _list_join(':', v) for k, v in val.items()])
         else:
             # hope that key_val_dict_to_string encodes value properly
             string += key_val_dict_to_str({key: val})


### PR DESCRIPTION
Fix behavior of `dict_to_gap_fit_string()` in gap_simple.py so that dicts actually become colon separated lists (functionality is actually in `wfl.utils.quip_cli_strings()`

closes #68 