### PR TITLE
Get rid of usage of all_or_none=True force=True

### DIFF
--- a/wfl/autoparallelize/pool.py
+++ b/wfl/autoparallelize/pool.py
@@ -133,7 +133,7 @@ def do_in_pool(npool=None, chunksize=1, iterable=None, outputspec=None, op=None,
         results = map_f(functools.partial(_wrapped_autopara_wrappable, op, iterable_arg, args, kwargs), items_inputs_generator)
 
         if not wfl_mpipool:
-            # only close pool if its from multiprocessing.pool
+            # only close pool if it's from multiprocessing.pool
             pool.close()
 
         # always loop over results to trigger lazy imap()
@@ -144,6 +144,11 @@ def do_in_pool(npool=None, chunksize=1, iterable=None, outputspec=None, op=None,
                         continue
                     did_no_work = False
                     outputspec.write(at, from_input_file=from_input_file)
+
+        if not wfl_mpipool:
+            # call join pool (prevent pytest-cov deadlock as per https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html)
+            # but only if it's from multiprocessing.pool
+            pool.join()
 
     else:
         # do directly, still not trivial because of chunksize

--- a/wfl/cli/dft_convergence_test.py
+++ b/wfl/cli/dft_convergence_test.py
@@ -41,8 +41,7 @@ def cli(verbose, configuration, buildcell_inputs, buildcell_cmd, n_per_config, p
     for filename in buildcell_inputs:
         with open(filename) as fin:
             buildcell_input = fin.read()
-        c_out = OutputSpec(file_root=run_dir, output_files=f'structs.{filename}.xyz',
-                              all_or_none=True, force=True)
+        c_out = OutputSpec(file_root=run_dir, output_files=f'structs.{filename}.xyz'),
         structs.append(run_buildcell(c_out, range(n_per_config), buildcell_cmd=buildcell_cmd,
                                      buildcell_input=buildcell_input, verbose=verbose))
     # merge
@@ -68,8 +67,7 @@ def cli(verbose, configuration, buildcell_inputs, buildcell_cmd, n_per_config, p
             # set desired value
             run_kwargs[key] = param_val
 
-            evaluated_structs = OutputSpec(file_root=run_dir, output_files=f'DFT_evaluated.{key}_{param_val}.xyz',
-                                              all_or_none=True, force=True)
+            evaluated_structs = OutputSpec(file_root=run_dir, output_files=f'DFT_evaluated.{key}_{param_val}.xyz')
 
             dft_evaluated[key][param_val] = evaluate_dft(
                     inputs=structs, outputs=evaluated_structs,


### PR DESCRIPTION
This behavior is now the default.  Changes all in cli files.

closes #80 