### PR TITLE
Fix bug in creating ConfigSet for defect confs in do_MD_bulk_defect_step()

### DIFF
--- a/wfl/cli/gap_rss_iter_fit.py
+++ b/wfl/cli/gap_rss_iter_fit.py
@@ -746,7 +746,7 @@ def do_MD_bulk_defect_step(ctx, cur_iter, minima_file, verbose):
         # NOTE: grouping all the defect configurations this way makes for better potential parallelism
         # since all the MDs can run side by side, but possibly worse restart for interrupted jobs, since the
         # results are all-or-none on the entire set.
-        groups[grp_label]['defect_confs'] = ConfigSet(input_configs=defect_confs)
+        groups[grp_label]['defect_confs'] = ConfigSet(input_configsets=defect_confs)
 
     # NOTE: perhaps the hard-wiring of specific md.sample parameters should be replaced with an
     # 'md_kwargs' param, similar to 'optimize_kwargs'

--- a/wfl/configset.py
+++ b/wfl/configset.py
@@ -141,10 +141,12 @@ class ConfigSet:
                     self.input_configs = [[self.input_configs]]
                 elif isinstance(first_config, Atoms):
                     # iterable(Atoms), store as 1 group
-                    self.input_configs = [self.input_configs]
+                    self.input_configs = [list(self.input_configs)]
                 else:
+                    input_configs_orig = self.input_configs
+                    self.input_configs = []
                     # check for iterable(iterable(Atoms))
-                    for sub_iter in self.input_configs:
+                    for sub_iter in input_configs_orig:
                         check = "inner iterator is iterable"
                         try:
                             first_subconfig = next(iter(sub_iter))
@@ -154,6 +156,7 @@ class ConfigSet:
                         if not isinstance(first_subconfig, Atoms):
                             check = "inner iterator contains Atoms"
                             raise TypeError
+                        self.input_configs.append(list(sub_iter))
             except StopIteration:
                 # empty iterable
                 self.input_configs = [[]]


### PR DESCRIPTION
Create ConfigSet for defect confs with `input_configsets` instead of `input_configs`.

Also, actually make sure stored iterables are lists when `ConfigSet` gets `input_configs`.