### PR TITLE
replace routine specific vars like WFL_GAP_SIMPLE_FIT_REMOTE_INFO, all use WFL_EXPYRE_INFO

### DIFF
--- a/.github/workflows_assets/config.json
+++ b/.github/workflows_assets/config.json
@@ -1,10 +1,10 @@
 { "systems": {
     "github": { "host": null,
         "scheduler": "slurm",
-        "header": ["#SBATCH --nodes={nnodes}",
-                   "#SBATCH --ntasks={ncores}",
-                   "#SBATCH --ntasks-per-node={ncores_per_node}"],
-        "partitions": { "standard":  { "ncores" : 2, "max_time" : null, "max_mem" : "10GB" } }
+        "header": ["#SBATCH --nodes={num_nodes}",
+                   "#SBATCH --ntasks={num_cores}",
+                   "#SBATCH --ntasks-per-node={num_cores_per_node}"],
+        "partitions": { "standard":  { "num_cores" : 2, "max_time" : null, "max_mem" : "10GB" } }
     }
   }
 }

--- a/docs/source/examples.md.md
+++ b/docs/source/examples.md.md
@@ -146,13 +146,13 @@ expyre config.json:
         "scheduler": "slurm",
         "commands": ["source /work/e89/e89/eg475/.bashrc",  "echo $(date)", "hostname"],
         "header": ["#SBATCH --nodes={nnodes}",
-                   "#SBATCH --tasks-per-node={ncores_per_node}",
+                   "#SBATCH --tasks-per-node={num_cores_per_node}",
                    "#SBATCH --cpus-per-task=1",
                    "#SBATCH --account=change-me",
                    "#SBATCH --qos=standard"],
                 "rundir": "/work/e89/e89/eg475/expyre_rundir",
-        "partitions": {"standard" : {"ncores": 128, "max_time" : "24h", "max_mem": "256G"},
-                       "highmem" : {"ncores": 128, "max_time" : "24h", "max_mem": "512G"}}
+        "partitions": {"standard" : {"num_cores": 128, "max_time" : "24h", "max_mem": "256G"},
+                       "highmem" : {"num_cores": 128, "max_time" : "24h", "max_mem": "512G"}}
                  }
 }}
 

--- a/docs/source/examples.orca.md
+++ b/docs/source/examples.orca.md
@@ -59,10 +59,10 @@ First, one need a configuration (`config.json`) that specifies what "resources" 
     "local": { "host": null,
         "scheduler": "sge",
         "commands": [  "echo $(date)", "hostname"],
-        "header": ["#$ -pe smp {ncores_per_node}"],
+        "header": ["#$ -pe smp {num_cores_per_node}"],
         "rundir": "/data/eg475/run_expyre",
-        "partitions": {"any":        {"ncores": 32, "max_time": "168h", "max_mem": "50GB"},
-                       "any@node15": {"ncores": 16, "max_time": "168h", "max_mem": "47GB"},
+        "partitions": {"any":        {"num_cores": 32, "max_time": "168h", "max_mem": "50GB"},
+                       "any@node15": {"num_cores": 16, "max_time": "168h", "max_mem": "47GB"},
                     }
             }
 }}
@@ -84,7 +84,7 @@ remote_ifno = {
 * `sys_name` - queue/system/cluster name to execute the job on. One fo the entries in `config.json`
 * `job_name` - prefix for the job's name on the queue (converted to `#$ -N` bit of the header on SGE).
 * `resources` - how many resources the job should require from the queue.
-    * `"num_cores": 4` - ask for 4 cores. That's executed by `"header": ["#$ -pe smp {ncores_per_node}"]` of `config.json`. 
+    * `"num_cores": 4` - ask for 4 cores. That's executed by `"header": ["#$ -pe smp {num_cores_per_node}"]` of `config.json`. 
     * `partitions` - name of the queue, converted to `#$ -q any` in this example that uses SGE. ExPyRe uses RegEx to find matching partition names, so `any$` will only pick the first of the two partitions specified in `config.json`. 
     * `max_time` - time requirement for the job, converted to `#$ -l h_rt=4:00:00` in this example.
 * `partial_node` - assumes that the que works in "node non-exclusive" way, multiple jobs may be run on a given node and allows picking a partition (`any` in this case) even if it has more cores available (32 here) than the number of cores needed for the job (4 in this case). 
@@ -134,10 +134,10 @@ Below is an example of corresponding `config.json`
         "local": { "host": null,
             "scheduler": "sge",
             "commands": [  "echo $(date)", "hostname"],
-            "header": ["#$ -pe smp {ncores_per_node}"],
+            "header": ["#$ -pe smp {num_cores_per_node}"],
             "rundir": "/data/eg475/run_expyre",
-            "partitions": {"any":        {"ncores": 32, "max_time": "168h", "max_mem": "50GB"},
-                           "any@node15": {"ncores": 16, "max_time": "168h", "max_mem": "47GB"},
+            "partitions": {"any":        {"num_cores": 32, "max_time": "168h", "max_mem": "50GB"},
+                           "any@node15": {"num_cores": 16, "max_time": "168h", "max_mem": "47GB"},
                         }
                 }
     }}

--- a/tests/test_ace_fitting.py
+++ b/tests/test_ace_fitting.py
@@ -133,5 +133,5 @@ def test_ace_fit_remote(request, tmp_path, expyre_systems, monkeypatch, remotein
 
         remoteinfo_env(ri)
 
-        monkeypatch.setenv('WFL_ACE_FIT_EXPYRE_INFO', json.dumps(ri))
+        monkeypatch.setenv('WFL_EXPYRE_INFO', json.dumps(ri))
         test_ace_fit(request, tmp_path, monkeypatch, run_dir=f'run_dir_{sys_name}')

--- a/tests/test_buildcell.py
+++ b/tests/test_buildcell.py
@@ -21,7 +21,7 @@ def test_buildcell_remote(tmp_path, expyre_systems, monkeypatch, remoteinfo_env)
 
 
 def do_buildcell_remote(tmp_path, sys_name, monkeypatch, remoteinfo_env):
-    ri = {'sys_name': sys_name, 'job_name': 'test_'+sys_name,
+    ri = {'sys_name': sys_name, 'job_name': 'pytest_'+sys_name,
           'resources': {'max_time': '1h', 'num_nodes': 1},
           'num_inputs_per_queued_job': -36, 'check_interval': 10}
 

--- a/tests/test_gap_fitting_multistage.py
+++ b/tests/test_gap_fitting_multistage.py
@@ -125,7 +125,7 @@ def test_gap_multistage_fit_remote(request, tmp_path, quippy, expyre_systems, mo
 
         remoteinfo_env(ri)
 
-        monkeypatch.setenv('WFL_GAP_MULTISTAGE_FIT_EXPYRE_INFO', json.dumps(ri))
+        monkeypatch.setenv('WFL_EXPYRE_INFO', json.dumps(ri))
         test_gap_multistage_fit(request, tmp_path, quippy, monkeypatch, run_dir=f'run_dir_{sys_name}')
 
 

--- a/tests/test_gap_fitting_simple.py
+++ b/tests/test_gap_fitting_simple.py
@@ -120,5 +120,5 @@ def test_fitting_gap_cli_remote(quippy, tmp_path, expyre_systems, monkeypatch, r
 
         remoteinfo_env(ri)
 
-        monkeypatch.setenv('WFL_GAP_SIMPLE_FIT_EXPYRE_INFO', json.dumps(ri))
+        monkeypatch.setenv('WFL_EXPYRE_INFO', json.dumps(ri))
         test_fitting_gap_cli(quippy, tmp_path)

--- a/tests/test_remote_run.py
+++ b/tests/test_remote_run.py
@@ -46,7 +46,7 @@ def test_vasp_fail(tmp_path, expyre_systems, monkeypatch, remoteinfo_env):
 
 
 def do_vasp_fail(tmp_path, sys_name, monkeypatch, remoteinfo_env):
-    ri = {'sys_name': sys_name, 'job_name': 'test_vasp_'+sys_name,
+    ri = {'sys_name': sys_name, 'job_name': 'pytest_vasp_'+sys_name,
           'env_vars' : ['VASP_COMMAND=NONE', 'VASP_COMMAND_GAMMA=NONE'],
           'input_files' : ['POTCARs'],
           'resources': {'max_time': '5m', 'num_nodes': 1},
@@ -91,7 +91,7 @@ def do_vasp_fail(tmp_path, sys_name, monkeypatch, remoteinfo_env):
 
 
 def do_generic_calc(tmp_path, sys_name, monkeypatch, remoteinfo_env):
-    ri = {'sys_name': sys_name, 'job_name': 'test_'+sys_name,
+    ri = {'sys_name': sys_name, 'job_name': 'pytest_'+sys_name,
           'resources': {'max_time': '1h', 'num_nodes': 1},
           'num_inputs_per_queued_job': -36, 'check_interval': 10}
 
@@ -162,7 +162,7 @@ def do_generic_calc(tmp_path, sys_name, monkeypatch, remoteinfo_env):
 
 
 def do_minim(tmp_path, sys_name, monkeypatch, remoteinfo_env):
-    ri = {'sys_name': sys_name, 'job_name': 'test_'+sys_name,
+    ri = {'sys_name': sys_name, 'job_name': 'pytest_'+sys_name,
           'resources': {'max_time': '1h', 'num_nodes': 1},
           'num_inputs_per_queued_job': -36, 'check_interval': 10}
 

--- a/wfl/autoparallelize/base.py
+++ b/wfl/autoparallelize/base.py
@@ -117,6 +117,7 @@ def autoparallelize(func, *args, def_autopara_info={}, **kwargs):
     The autoparallelized function can then be called with 
 
     .. code-block:: python
+
         parallelized_op(inputs, outputs, [args of op], autopara_info=AutoparaInfo(arg1=val1, ...), [kwargs of op])
 
 

--- a/wfl/autoparallelize/remote.py
+++ b/wfl/autoparallelize/remote.py
@@ -18,7 +18,7 @@ def do_remotely(remote_info, hash_ignore=[], num_inputs_per_python_subprocess=1,
 
     Parameters
     ----------
-    remote_info: RemoteInfo or dict
+    remote_info: RemoteInfo
         object with all information on remote job, including system, resources, job num_inputs_per_python_subprocess, etc, or dict of kwargs for its constructor
     quiet: bool, default False
         do not output (to stderr) progress info
@@ -27,9 +27,6 @@ def do_remotely(remote_info, hash_ignore=[], num_inputs_per_python_subprocess=1,
     """
     if ExPyRe is None:
         raise RuntimeError('Cannot run as remote jobs since expyre module could not be imported')
-
-    if not isinstance(remote_info, RemoteInfo):
-        remote_info = RemoteInfo(**remote_info)
 
     if remote_info.num_inputs_per_queued_job < 0:
         remote_info.num_inputs_per_queued_job = -remote_info.num_inputs_per_queued_job * num_inputs_per_python_subprocess

--- a/wfl/autoparallelize/utils.py
+++ b/wfl/autoparallelize/utils.py
@@ -1,3 +1,8 @@
+import sys
+import os
+import json
+import traceback as tb
+import re
 import itertools
 
 
@@ -21,3 +26,66 @@ def grouper(n, iterable):
         if not chunk:
             return
         yield chunk
+
+
+def get_remote_info(remote_info, remote_label):
+    """get remote_info dict from passed in dict, label, and/or env. var
+
+    Parameters
+    ----------
+
+    remote_info: RemoteInfo, default content of env var WFL_EXPYRE_INFO
+        information for running on remote machine.  If None, use WFL_EXPYRE_INFO env var, as
+        json file if string, as RemoteInfo kwargs dict if keys include sys_name, or as dict of
+        RemoteInfo kwrgs with keys that match end of stack trace with function names separated by '.'.
+    remote_label: str, default None
+        remote_label to use for operation, to match to remote_info dict keys.  If none, use calling routine filename '::' calling function
+
+    Returns
+    -------
+    remote_info dict or RemoteInfo or None
+    """
+    if remote_info is None and 'WFL_EXPYRE_INFO' in os.environ:
+        try:
+            remote_info = json.loads(os.environ['WFL_EXPYRE_INFO'])
+        except Exception as exc:
+            remote_info = os.environ['WFL_EXPYRE_INFO']
+            if ' ' in remote_info:
+                # if it's not JSON, it must be a filename, so presence of space is suspicious
+                warnings.warn(f'remote_info from WFL_EXPYRE_INFO has whitespace, but not parseable as JSON with error {exc}')
+        if isinstance(remote_info, str):
+            # filename
+            with open(remote_info) as fin:
+                remote_info = json.load(fin)
+        if 'sys_name' in remote_info:
+            # remote_info directly in top level dict
+            warnings.warn('WFL_EXPYRE_INFO appears to be a RemoteInfo kwargs, using directly')
+        else:
+            if remote_label is None:
+                # no explicit remote_label for the remote run was passed into function, so
+                # need to match end of stack trace to remote_info dict keys, here we
+                # construct object to compare to
+                # last stack item is always autoparallelize, so ignore it
+                stack_remote_label = [fs[0] + '::' + fs[2] for fs in tb.extract_stack()[:-1]]
+            else:
+                stack_remote_label = []
+            while len(stack_remote_label) > 0 and (stack_remote_label[-1].endswith('autoparallelize/base.py::autoparallelize') or
+                                                   stack_remote_label[-1].endswith('autoparallelize/base.py::_autoparallelize_ll') or
+                                                   stack_remote_label[-1].endswith('autoparallelize/utils.py::get_remote_info')):
+                # replace autoparallelize stack entry with one for desired function name
+                stack_remote_label.pop()
+            #DEBUG print("DEBUG stack_remote_label", stack_remote_label)
+            match = False
+            for ri_k in remote_info:
+                ksplit = [sl.strip() for sl in ri_k.split(',')]
+                # match dict key to remote_label if present, otherwise end of stack
+                if ((remote_label is None and all([re.search(kk + '$', sl) for sl, kk in zip(stack_remote_label[-len(ksplit):], ksplit)])) or
+                    (remote_label == ri_k)):
+                    sys.stderr.write(f'WFL_EXPYRE_INFO matched key {ri_k} for remote_label {remote_label}\n')
+                    remote_info = remote_info[ri_k]
+                    match = True
+                    break
+            if not match:
+                remote_info = None
+
+    return remote_info

--- a/wfl/fit/gap/simple.py
+++ b/wfl/fit/gap/simple.py
@@ -6,13 +6,13 @@ from copy import deepcopy
 
 from wfl.configset import ConfigSet
 from wfl.utils.quip_cli_strings import dict_to_quip_str
-from ..utils import get_RemoteInfo
+from wfl.autoparallelize.utils import get_remote_info
 from .relocate import gap_relocate
 
 from expyre import ExPyRe
 
 def run_gap_fit(fitting_configs, fitting_dict, stdout_file, gap_fit_exec="gap_fit",
-                verbose=True, do_fit=True, remote_info=None, **kwargs):
+                verbose=True, do_fit=True, remote_info=None, remote_label=None, **kwargs):
     """Runs gap_fit
 
     Parameters
@@ -31,21 +31,25 @@ def run_gap_fit(fitting_configs, fitting_dict, stdout_file, gap_fit_exec="gap_fi
     remote_info: dict or wfl.autoparallelize.utils.RemoteInfo, or '_IGNORE' or None
         If present and not None and not '_IGNORE', RemoteInfo or dict with kwargs for RemoteInfo
         constructor which triggers running job in separately queued job on remote machine.  If None,
-        will try to use env var WFL_GAP_SIMPLE_FIT_EXPYRE_INFO used (see below). '_IGNORE' is for
+        will try to use env var WFL_EXPYRE_INFO used (see below). '_IGNORE' is for
         internal use, to ensure that remotely running job does not itself attempt to spawn another
         remotely running job.
+    remote_label: str, default None
+        remote label to patch in WFL_EXPYRE_INFO
     kwargs
         any key:val pair will be added to the fitting str
 
     Environment Variables
     ---------------------
-    WFL_GAP_SIMPLE_FIT_EXPYRE_INFO: JSON dict or name of file containing JSON with kwargs for RemoteInfo
+    WFL_EXPYRE_INFO: JSON dict or name of file containing JSON with kwargs for RemoteInfo
         contructor to be used to run fitting in separate queued job
     WFL_GAP_FIT_OMP_NUM_THREADS: number of threads to set for OpenMP of gap_fit
     """
     assert 'atoms_filename' not in fitting_dict and 'at_file' not in fitting_dict
 
-    remote_info = get_RemoteInfo(remote_info, 'WFL_GAP_SIMPLE_FIT_EXPYRE_INFO')
+    if remote_info != '_IGNORE':
+        remote_info = get_remote_info(remote_info, remote_label)
+
     if remote_info is not None and remote_info != '_IGNORE':
         input_files = remote_info.input_files.copy()
         output_files = remote_info.output_files.copy()

--- a/wfl/fit/utils.py
+++ b/wfl/fit/utils.py
@@ -108,19 +108,3 @@ def copy_properties(configs, ref_property_keys, stress_to_virial=True, force=Tru
         fix_stress_virial(configs, ref_property_keys, stress_key)
 
     return ref_property_keys
-
-
-def get_RemoteInfo(remote_info, env_var):
-    if remote_info is None and env_var in os.environ:
-        try:
-            # interpret as JSON string
-            remote_info = json.loads(os.environ[env_var])
-        except:
-            # interpret as name of file with JSON in it
-            with open(os.environ[env_var]) as fin:
-                remote_info = json.load(fin)
-
-    if isinstance(remote_info, dict):
-        remote_info = RemoteInfo(**remote_info)
-
-    return remote_info


### PR DESCRIPTION
Replace routine-specific env vars with `RemoteInfo` dicts with values in `WFL_EXPYRE_INFO`.  

Refactor logic to get `remote_info` from `_autoparallelize_ll()` into `autoparallelize/utils.py::get_remote_info()`, so it can be used by other functions, and call it from all routines that need a `RemoteInfo` `kwargs` dict, in particular for now GAP and ACE fitting functions.