### PR TITLE
pytest with WFL_NUM_PYTHON_SUBPROCESSES > 1

### DIFF
--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -109,6 +109,8 @@ jobs:
           #
           export EXPYRE_PYTEST_SYSTEMS=github
           export WFL_PYTEST_BUILDCELL=$HOME/bin/buildcell
+          export WFL_NUM_PYTHON_SUBPROCESSES=2
+          export OMP_NUM_THREADS=1
           pytest --runremote --basetemp $HOME/pytest_plain -rxXs
 
       - name: Test with pytest - coverage
@@ -119,6 +121,8 @@ jobs:
           #
           export EXPYRE_PYTEST_SYSTEMS=github
           export WFL_PYTEST_BUILDCELL=$HOME/bin/buildcell
+          export WFL_NUM_PYTHON_SUBPROCESSES=2
+          export OMP_NUM_THREADS=1
           pytest -v --cov=wfl --cov-report term --cov-report html --cov-config=tests/.coveragerc --cov-report term-missing --cov-report term:skip-covered --runremote --basetemp $HOME/pytest_cov -rxXs
 
       - name: MPI tests -- plain
@@ -126,6 +130,8 @@ jobs:
         run: |
           # envvar and test run - No coverage
           export WFL_MPIPOOL=2
+          export WFL_NUM_PYTHON_SUBPROCESSES=2
+          export OMP_NUM_THREADS=1
           mpirun -n 2 pytest --with-mpi -k mpi
 
       - name: MPI tests -- coverage
@@ -133,6 +139,8 @@ jobs:
         run: |
           # envvar and coverage Appended to the previous
           export WFL_MPIPOOL=2
+          export WFL_NUM_PYTHON_SUBPROCESSES=2
+          export OMP_NUM_THREADS=1
           mpirun -n 2 pytest --cov=wfl --cov-report term --cov-config=tests/.coveragerc --cov-report term-missing --cov-report term:skip-covered --with-mpi -k mpi --cov-append
 
       - name: 'Upload Coverage Data'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,12 @@ from pathlib import Path
 import shutil
 
 
+@pytest.fixture(autouse=True)
+def env_setup(monkeypatch):
+    if "WFL_NUM_PYTHON_SUBPROCESSES" not in os.environ:
+        monkeypatch.setenv("WFL_NUM_PYTHON_SUBPROCESSES", "2")
+
+
 def do_init_mpipool():
     import wfl.autoparallelize.mpipool_support
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,12 @@ import shutil
 
 @pytest.fixture(autouse=True)
 def env_setup(monkeypatch):
+    # actually run in parallel by default
     if "WFL_NUM_PYTHON_SUBPROCESSES" not in os.environ:
         monkeypatch.setenv("WFL_NUM_PYTHON_SUBPROCESSES", "2")
+    # disable OpenMP because it conflicts with multiprocessing.pool on some machines (e.g. github CI)
+    if "OMP_NUM_THREADS" not in os.environ:
+        monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
 
 def do_init_mpipool():

--- a/tests/test_calc_descriptor.py
+++ b/tests/test_calc_descriptor.py
@@ -48,7 +48,7 @@ def test_calc_descriptor_average_any_atomic_number_normalization():
 
     assert 1.0 == approx(np.linalg.norm(list(ats_desc)[0].info['desc']))
 
-    del ats[0].info["desc"]
+    ats[0].info.pop("desc", None)
     ats_desc = calc(ci, OutputSpec(),
                     ['soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 average n_species=2 species_Z={6 14}', 
                      'soap n_max=3 l_max=3 cutoff=5.0 atom_sigma=0.5 average n_species=2 species_Z={6 14}'], 'desc', normalize=False)

--- a/tests/test_ref_error.py
+++ b/tests/test_ref_error.py
@@ -85,8 +85,8 @@ def test_ref_error(tmp_path, ref_atoms):
 
 
 def test_err_from_calc(ref_atoms):
-    _ = calc_run(ref_atoms, OutputSpec(), LennardJones(sigma=0.75), output_prefix='calc_')
-    ref_err_dict = err_from_calculated_ats(ref_atoms, ref_property_prefix='REF_', calc_property_prefix='calc_',
+    ref_atoms_calc = calc_run(ref_atoms, OutputSpec(), LennardJones(sigma=0.75), output_prefix='calc_')
+    ref_err_dict = err_from_calculated_ats(ref_atoms_calc, ref_property_prefix='REF_', calc_property_prefix='calc_',
                                           properties=['energy_per_atom', 'forces', 'virial_per_atom'])
 
     print(ref_err_dict)
@@ -99,11 +99,11 @@ def test_err_from_calc(ref_atoms):
 
 
 def test_ref_error_properties(ref_atoms):
-    _ = calc_run(ref_atoms, OutputSpec(), LennardJones(sigma=0.75), output_prefix='calc_')
+    ref_atoms_calc = calc_run(ref_atoms, OutputSpec(), LennardJones(sigma=0.75), output_prefix='calc_')
 
     # both energy and per atom
     ref_err_dict = err_from_calculated_ats(
-        ref_atoms, ref_property_prefix='REF_', calc_property_prefix='calc_', properties=["energy", "energy_per_atom"])
+        ref_atoms_calc, ref_property_prefix='REF_', calc_property_prefix='calc_', properties=["energy", "energy_per_atom"])
 
     assert len(ref_err_dict.keys()) == 1
     assert len(ref_err_dict['_ALL_'].keys()) == 2
@@ -116,7 +116,7 @@ def test_ref_error_properties(ref_atoms):
 
     # only energy
     ref_err_dict = err_from_calculated_ats(
-        ref_atoms, ref_property_prefix='REF_', calc_property_prefix='calc_', properties=["energy"])
+        ref_atoms_calc, ref_property_prefix='REF_', calc_property_prefix='calc_', properties=["energy"])
 
     assert len(ref_err_dict.keys()) == 1
     assert len(ref_err_dict['_ALL_'].keys()) == 1
@@ -126,7 +126,7 @@ def test_ref_error_properties(ref_atoms):
 
     # only stress
     ref_err_dict = err_from_calculated_ats(
-        ref_atoms, ref_property_prefix='REF_', calc_property_prefix='calc_', properties=["stress", "virial"])
+        ref_atoms_calc, ref_property_prefix='REF_', calc_property_prefix='calc_', properties=["stress", "virial"])
 
     assert len(ref_err_dict.keys()) == 1
     assert len(ref_err_dict['_ALL_'].keys()) == 2
@@ -139,24 +139,24 @@ def test_ref_error_properties(ref_atoms):
 
 
 def test_ref_error_forces(ref_atoms):
-    _ = calc_run(ref_atoms, OutputSpec(), LennardJones(sigma=0.75), output_prefix='calc_')
+    ref_atoms_calc = calc_run(ref_atoms, OutputSpec(), LennardJones(sigma=0.75), output_prefix='calc_')
 
     # forces by element
     ref_err_dict = err_from_calculated_ats(
-        ref_atoms, ref_property_prefix='REF_', calc_property_prefix='calc_', properties=["forces"],
+        ref_atoms_calc, ref_property_prefix='REF_', calc_property_prefix='calc_', properties=["forces"],
         forces_by_element=True)
     assert ref_err_dict['_ALL_']['forces'][13][0] == 40
     assert approx(ref_err_dict['_ALL_']['forces'][13][1]) == __ALL__forces
 
     # remove error info so next call won't complain
-    for at in ref_atoms:
+    for at in ref_atoms_calc:
         at.info = {k: v for k, v in at.info.items() if not k.endswith('_error')}
-    for at in ref_atoms:
+    for at in ref_atoms_calc:
         at.arrays = {k: v for k, v in at.arrays.items() if not k.endswith('_error')}
 
     # forces by component
     ref_err_dict = err_from_calculated_ats(
-        ref_atoms, ref_property_prefix='REF_', calc_property_prefix='calc_', properties=["forces"],
+        ref_atoms_calc, ref_property_prefix='REF_', calc_property_prefix='calc_', properties=["forces"],
         forces_by_component=True, forces_by_element=True)
     assert ref_err_dict['_ALL_']['forces'][13][0] == 120
     assert approx(ref_err_dict['_ALL_']['forces'][13][1]) == 29490136730.741474
@@ -164,9 +164,9 @@ def test_ref_error_forces(ref_atoms):
 
 @pytest.mark.filterwarnings("ignore:missing reference:UserWarning")
 def test_ref_error_missing(ref_atoms):
-    _ = calc_run(ref_atoms, OutputSpec(), LennardJones(sigma=0.75), output_prefix='calc_')
+    ref_atoms_calc = calc_run(ref_atoms, OutputSpec(), LennardJones(sigma=0.75), output_prefix='calc_')
 
-    ref_atoms_list = [at for at in ref_atoms]
+    ref_atoms_list = [at for at in ref_atoms_calc]
 
     for at in ref_atoms_list:
         if at.info.get("category", None) == 0:


### PR DESCRIPTION
Fix tests that fail when WFL_NUM_PYTHON_SUBPROCESSES > 1, and run with 2 as the default if env var is not already set