### PR TITLE
use forkserver for autopara Pool

### DIFF
--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -109,8 +109,6 @@ jobs:
           #
           export EXPYRE_PYTEST_SYSTEMS=github
           export WFL_PYTEST_BUILDCELL=$HOME/bin/buildcell
-          export WFL_NUM_PYTHON_SUBPROCESSES=2
-          export OMP_NUM_THREADS=1
           pytest --runremote --basetemp $HOME/pytest_plain -rxXs
 
       - name: Test with pytest - coverage
@@ -121,8 +119,6 @@ jobs:
           #
           export EXPYRE_PYTEST_SYSTEMS=github
           export WFL_PYTEST_BUILDCELL=$HOME/bin/buildcell
-          export WFL_NUM_PYTHON_SUBPROCESSES=2
-          export OMP_NUM_THREADS=1
           pytest -v --cov=wfl --cov-report term --cov-report html --cov-config=tests/.coveragerc --cov-report term-missing --cov-report term:skip-covered --runremote --basetemp $HOME/pytest_cov -rxXs
 
       - name: MPI tests -- plain
@@ -130,8 +126,6 @@ jobs:
         run: |
           # envvar and test run - No coverage
           export WFL_MPIPOOL=2
-          export WFL_NUM_PYTHON_SUBPROCESSES=2
-          export OMP_NUM_THREADS=1
           mpirun -n 2 pytest --with-mpi -k mpi
 
       - name: MPI tests -- coverage
@@ -139,8 +133,6 @@ jobs:
         run: |
           # envvar and coverage Appended to the previous
           export WFL_MPIPOOL=2
-          export WFL_NUM_PYTHON_SUBPROCESSES=2
-          export OMP_NUM_THREADS=1
           mpirun -n 2 pytest --cov=wfl --cov-report term --cov-config=tests/.coveragerc --cov-report term-missing --cov-report term:skip-covered --with-mpi -k mpi --cov-append
 
       - name: 'Upload Coverage Data'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,12 +11,8 @@ import shutil
 
 @pytest.fixture(autouse=True)
 def env_setup(monkeypatch):
-    # actually run in parallel by default
     if "WFL_NUM_PYTHON_SUBPROCESSES" not in os.environ:
         monkeypatch.setenv("WFL_NUM_PYTHON_SUBPROCESSES", "2")
-    # disable OpenMP because it conflicts with multiprocessing.pool on some machines (e.g. github CI)
-    if "OMP_NUM_THREADS" not in os.environ:
-        monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
 
 def do_init_mpipool():

--- a/wfl/autoparallelize/pool.py
+++ b/wfl/autoparallelize/pool.py
@@ -5,6 +5,7 @@ import inspect
 
 import functools
 from multiprocessing.pool import Pool
+import multiprocessing
 
 from wfl.configset import ConfigSet
 from wfl.autoparallelize.mpipool_support import wfl_mpipool
@@ -124,7 +125,7 @@ def do_in_pool(num_python_subprocesses=None, num_inputs_per_python_subprocess=1,
                 initializer_args = {'initializer': initializer[0], 'initargs': initializer[1]}
             else:
                 initializer_args = {}
-            pool = Pool(num_python_subprocesses, **initializer_args)
+            pool = Pool(num_python_subprocesses, context=multiprocessing.get_context("forkserver"), **initializer_args)
 
         if wfl_mpipool:
             map_f = pool.map


### PR DESCRIPTION
Using start method `"forkserver"` for `multiprocessing.Pool`'s context should behave better with OpenMP.