### PR TITLE
bug fix in autoparainfo

### DIFF
--- a/wfl/autoparallelize/autoparainfo.py
+++ b/wfl/autoparallelize/autoparainfo.py
@@ -58,8 +58,8 @@ class AutoparaInfo:
             if not hasattr(self, k):
                 setattr(self, k, def_kwargs.pop(k, AutoparaInfo._kwargs[k]))
             elif k in AutoparaInfo._kwargs:
-                # it is a valid default, but was already set in AutoparaInfo, so not 
-                # overwriting with defaults
+                # it is a valid default, but was already set in AutoparaInfo by the user,
+                #  so not overwriting with defaults
                 del def_kwargs[k] 
 
 

--- a/wfl/autoparallelize/autoparainfo.py
+++ b/wfl/autoparallelize/autoparainfo.py
@@ -57,9 +57,14 @@ class AutoparaInfo:
         for k in AutoparaInfo._kwargs:
             if not hasattr(self, k):
                 setattr(self, k, def_kwargs.pop(k, AutoparaInfo._kwargs[k]))
+            elif k in AutoparaInfo._kwargs:
+                # it is a valid default, but was already set in AutoparaInfo, so not 
+                # overwriting with defaults
+                del def_kwargs[k] 
+
 
         if len(def_kwargs) != 0:
-            raise ValueError("def_kwargs contained unknown keywords {list(def_kwargs.keys())}")
+            raise ValueError(f"def_kwargs contained unknown keywords {list(def_kwargs.keys())}")
 
 
     def __str__(self):

--- a/wfl/autoparallelize/autoparainfo.py
+++ b/wfl/autoparallelize/autoparainfo.py
@@ -57,7 +57,7 @@ class AutoparaInfo:
         for k in AutoparaInfo._kwargs:
             if not hasattr(self, k):
                 setattr(self, k, def_kwargs.pop(k, AutoparaInfo._kwargs[k]))
-            elif k in AutoparaInfo._kwargs:
+            else:
                 # it is a valid default, but was already set in AutoparaInfo by the user,
                 #  so not overwriting with defaults
                 del def_kwargs[k] 


### PR DESCRIPTION
@bernstei very quick bug fix - it used to be impossible to overwrite the AutoparaInfo defaults, set when parallelising a function. Please merge if this looks ok.