### PR TITLE
Update all parallelized functions to consistently use the new autoparallelize

### DIFF
--- a/tests/test_autoparallelize.py
+++ b/tests/test_autoparallelize.py
@@ -13,7 +13,7 @@ from wfl.autoparallelize.autoparainfo import AutoparaInfo
 
 
 def test_empty_iterator(tmp_path):
-    co = buildcell.run(OutputSpec(output_files=str(tmp_path / 'dummy.xyz')), range(0), buildcell_cmd='dummy', buildcell_input='dummy')
+    co = buildcell.run(range(0), OutputSpec(output_files=str(tmp_path / 'dummy.xyz')),  buildcell_cmd='dummy', buildcell_input='dummy')
 
     assert len([at for at in co]) == 0
 

--- a/tests/test_buildcell.py
+++ b/tests/test_buildcell.py
@@ -48,3 +48,4 @@ def do_buildcell(tmp_path, filename):
                       buildcell_cmd=os.environ['WFL_PYTEST_BUILDCELL'], buildcell_input=buildcell_input)
 
     assert len(list(co)) == 100
+

--- a/tests/test_buildcell.py
+++ b/tests/test_buildcell.py
@@ -44,7 +44,7 @@ def do_buildcell(tmp_path, filename):
 #MINSEP=0.5 Li-Li=2.7
 ##EXTRA_INFO RSS_min_vol_per_atom=10.0"""
 
-    co = buildcell.run(OutputSpec(output_files=str(tmp_path / filename)), range(100),
+    co = buildcell.run(range(100), OutputSpec(output_files=str(tmp_path / filename)), 
                       buildcell_cmd=os.environ['WFL_PYTEST_BUILDCELL'], buildcell_input=buildcell_input)
 
     assert len(list(co)) == 100

--- a/wfl/autoparallelize/__init__.py
+++ b/wfl/autoparallelize/__init__.py
@@ -1,4 +1,3 @@
-from .base import _autoparallelize_ll, autoparallelize, autoparallelize_docstring
-assert _autoparallelize_ll
+from .base import autoparallelize, autoparallelize_docstring
 assert autoparallelize
 assert autoparallelize_docstring

--- a/wfl/calculators/dft.py
+++ b/wfl/calculators/dft.py
@@ -6,7 +6,7 @@ Currently implemented codes:
 - VASP
 - Quantum Espresso
 """
-from wfl.autoparallelize import _autoparallelize_ll
+from wfl.autoparallelize.base import _autoparallelize_ll
 from wfl.calculators import castep, vasp, espresso
 
 

--- a/wfl/calculators/orca/__init__.py
+++ b/wfl/calculators/orca/__init__.py
@@ -15,7 +15,6 @@ from ase.calculators.calculator import CalculationFailed, Calculator, \
 import ase.calculators.orca
 
 from wfl.calculators.utils import clean_rundir, save_results
-from wfl.autoparallelize import _autoparallelize_ll
 from wfl.utils.misc import atoms_to_list, chunks
 from wfl.calculators.orca.basinhopping import BasinHoppingORCA
 

--- a/wfl/calculators/orca/basinhopping.py
+++ b/wfl/calculators/orca/basinhopping.py
@@ -10,7 +10,7 @@ from ase.calculators.calculator import all_changes, CalculationFailed
 from ase.calculators.calculator import Calculator
 
 from wfl.calculators import orca
-from wfl.autoparallelize import _autoparallelize_ll
+from wfl.autoparallelize.base import _autoparallelize_ll
 
 
 def evaluate_basin_hopping(inputs, outputs,

--- a/wfl/descriptors/quippy.py
+++ b/wfl/descriptors/quippy.py
@@ -8,7 +8,7 @@ try:
 except ModuleNotFoundError:
     pass
 
-from wfl.autoparallelize import _autoparallelize_ll
+from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 from wfl.utils.quip_cli_strings import dict_to_quip_str
 
 
@@ -69,42 +69,6 @@ def from_any_to_Descriptor(descriptor_src, verbose=False):
             descs[Zcenter].append(d)
 
     return descs
-
-
-def calc(inputs, outputs, descs, key, local=False, normalize=True, composition_weight=True, force=False, verbose=False):
-    """Calculates descriptors on a set of configs, I/O with ConfigSet/OutputSpec
-
-    Parameters
-    ----------
-    inputs: ConfigSet
-        input configurations
-    outputs: OutputSpec
-        where to write outputs
-    descs: str / list(str) / dict(Z : str)
-        descriptor (string or dict or quippy.descriptors.Descriptor) or list of descriptors (applied to all species) 
-        or dict of descriptors for each species (key is species or None for all species)
-        If global, combined descriptor will be concatenated.  If local and Z is not None, multiple arrays
-        entries will be created, one per Zcenter, named <key>_Z_<Zcenter>.
-    key: str
-        info/arrays key to store descriptor vectors
-    local: bool, default False
-        calculate descriptors for each atom
-    normalize: bool, default True
-        normalize final vector (e.g. if contributions from multiple descriptors were concatenated)
-    composition_weight: bool, default True
-        when concatenating contributions from different species for a global, weight each by composition fraction
-    force: bool, default False
-        overwrite key if already exists
-    verbose: bool, default False
-        verbose output
-
-    Returns
-    -------
-    ConfigSet 
-        OutputSpec.to_ConfigSet() Pointing to outputs
-    """
-    return _autoparallelize_ll(iterable=inputs, outputspec=outputs, op=calc_autopara_wrappable, descs=descs, key=key, local=local,
-                         force=force, verbose=verbose, normalize=normalize, composition_weight=composition_weight)
 
 
 def calc_autopara_wrappable(atoms, descs, key, local=False, normalize=True, composition_weight=True, force=False, verbose=False):
@@ -229,3 +193,10 @@ def calc_autopara_wrappable(atoms, descs, key, local=False, normalize=True, comp
             at.info[key] = combined_vec
 
     return atoms
+
+
+
+def calc(*args, **kwargs):
+    return autoparallelize(calc_autopara_wrappable, *args, **kwargs)
+calc.__doc__ = autoparallelize_docstring(calc_autopara_wrappable.__doc__, "Atoms")
+

--- a/wfl/generate/buildcell.py
+++ b/wfl/generate/buildcell.py
@@ -8,7 +8,7 @@ import spglib
 from ase.atoms import Atoms
 from ase.io.extxyz import key_val_str_to_dict
 
-from wfl.autoparallelize import _autoparallelize_ll
+from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 from wfl.utils.round_sig_figs import round_sig_figs
 
 
@@ -126,43 +126,6 @@ def conv_buildcell_out(buildcell_output):
     return ats
 
 
-def run(outputs, config_is, buildcell_cmd, buildcell_input, extra_info=None,
-        perturbation=0.0, skip_failures=True, symprec=0.01, verbose=False):
-    """Creates atomic configurations by repeatedly running buildcell, I/O with OutputSpec
-
-    Parameters
-    ----------
-    outputs: OutputSpec
-        where to write outputs
-    config_is: int / list(int)
-        numbers to set in buildcell_config_i info field
-        length sets number of configs generated
-    buildcell_cmd:
-        `buildcell` executable, including path if needed
-    buildcell_input: str
-        input file contents to buildcell, in the form of a single string
-    extra_info: dict, default {}
-        extra fields to place into created atoms info dict
-    perturbation: float, default 0.0
-        magnitude of perturbation to atomic positions with Atoms.rattle()
-    skip_failures: bool, default True
-        skip failed buildcell calls
-    symprec: float, default 0.01
-        precision for symmetry check
-    verbose: bool, default False
-        print some running info
-
-    Returns
-    ------
-        ConfigSet corresponding to output
-    """
-    if extra_info is None:
-        extra_info = {}
-    return _autoparallelize_ll(iterable=config_is, outputspec=outputs, op=run_autopara_wrappable,
-                         buildcell_cmd=buildcell_cmd, buildcell_input=buildcell_input,
-                         extra_info=extra_info, perturbation=perturbation, skip_failures=skip_failures,
-                         verbose=verbose, symprec=symprec)
-
 
 def run_autopara_wrappable(config_is, buildcell_cmd, buildcell_input, extra_info=None,
            perturbation=0.0, skip_failures=True, symprec=0.01, verbose=False):
@@ -243,3 +206,9 @@ def run_autopara_wrappable(config_is, buildcell_cmd, buildcell_input, extra_info
             atoms_list.append(at0)
 
     return atoms_list
+
+def run(*args, **kwargs):
+    if kwargs["extra_info"] is None:
+        kwargs["extra_info"] = {}
+    return autoparallelize(run_autopara_wrappable, *args, **kwargs)
+run.__doc__ = autoparallelize_docstring(run_autopara_wrappable.__doc__, "Atoms")

--- a/wfl/generate/buildcell.py
+++ b/wfl/generate/buildcell.py
@@ -208,7 +208,5 @@ def run_autopara_wrappable(config_is, buildcell_cmd, buildcell_input, extra_info
     return atoms_list
 
 def run(*args, **kwargs):
-    if kwargs["extra_info"] is None:
-        kwargs["extra_info"] = {}
     return autoparallelize(run_autopara_wrappable, *args, **kwargs)
 run.__doc__ = autoparallelize_docstring(run_autopara_wrappable.__doc__, "Atoms")

--- a/wfl/generate/md.py
+++ b/wfl/generate/md.py
@@ -8,7 +8,6 @@ from ase.md.velocitydistribution import MaxwellBoltzmannDistribution, Stationary
 from ase.md.verlet import VelocityVerlet
 from ase.units import GPa, fs
 
-# from wfl.autoparallelize import _autoparallelize_ll
 from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 from wfl.utils.at_copy_save_results import at_copy_save_results
 from wfl.utils.misc import atoms_to_list

--- a/wfl/generate/md.py
+++ b/wfl/generate/md.py
@@ -219,11 +219,12 @@ def sample(*args, **kwargs):
     # Normally each thread needs to call np.random.seed so that it will generate a different
     # set of random numbers.  This env var overrides that to produce deterministic output,
     # for purposes like testing
+    # EG: do we need a "hash_ignore" like in optimize.py?
     if 'WFL_DETERMINISTIC_HACK' in os.environ:
         initializer = (None, [])
     else:
         initializer = (np.random.seed, [])
-    def_autopara_info={"initializer":initializer,}
+    def_autopara_info={"initializer":initializer}
 
     return autoparallelize(sample_autopara_wrappable, *args, 
         def_autopara_info=def_autopara_info, **kwargs)

--- a/wfl/generate/md.py
+++ b/wfl/generate/md.py
@@ -8,7 +8,8 @@ from ase.md.velocitydistribution import MaxwellBoltzmannDistribution, Stationary
 from ase.md.verlet import VelocityVerlet
 from ase.units import GPa, fs
 
-from wfl.autoparallelize import _autoparallelize_ll
+# from wfl.autoparallelize import _autoparallelize_ll
+from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 from wfl.utils.at_copy_save_results import at_copy_save_results
 from wfl.utils.misc import atoms_to_list
 from wfl.utils.parallel import construct_calculator_picklesafe
@@ -16,28 +17,6 @@ from wfl.utils.pressure import sample_pressure
 from .utils import config_type_append
 
 bar = 1.0e-4 * GPa
-
-
-# run that operates on ConfigSet, for multiprocessing
-def sample(inputs, outputs, calculator, steps, dt,
-           temperature=None, temperature_tau=None, pressure=None, pressure_tau=None,
-           compressibility_fd_displ=0.01,
-           traj_step_interval=1, skip_failures=True, results_prefix='md_',
-           num_inputs_per_python_subprocess=1, verbose=False):
-    # Normally each thread needs to call np.random.seed so that it will generate a different
-    # set of random numbers.  This env var overrides that to produce deterministic output,
-    # for purposes like testing
-    if 'WFL_DETERMINISTIC_HACK' in os.environ:
-        initializer = (None, [])
-    else:
-        initializer = (np.random.seed, [])
-    return _autoparallelize_ll(iterable=inputs, outputspec=outputs, op=sample_autopara_wrappable, num_inputs_per_python_subprocess=num_inputs_per_python_subprocess,
-                         calculator=calculator, steps=steps, dt=dt,
-                         temperature=temperature, temperature_tau=temperature_tau,
-                         pressure=pressure, pressure_tau=pressure_tau,
-                         compressibility_fd_displ=compressibility_fd_displ,
-                         traj_step_interval=traj_step_interval, skip_failures=skip_failures,
-                         results_prefix=results_prefix, verbose=verbose, initializer=initializer)
 
 
 def sample_autopara_wrappable(atoms, calculator, steps, dt, temperature=None, temperature_tau=None,
@@ -235,3 +214,18 @@ def sample_autopara_wrappable(atoms, calculator, steps, dt, temperature=None, te
         all_trajs.append(traj)
 
     return all_trajs
+
+
+def sample(*args, **kwargs):
+    # Normally each thread needs to call np.random.seed so that it will generate a different
+    # set of random numbers.  This env var overrides that to produce deterministic output,
+    # for purposes like testing
+    if 'WFL_DETERMINISTIC_HACK' in os.environ:
+        initializer = (None, [])
+    else:
+        initializer = (np.random.seed, [])
+    def_autopara_info={"initializer":initializer,}
+
+    return autoparallelize(sample_autopara_wrappable, *args, 
+        def_autopara_info=def_autopara_info, **kwargs)
+sample.__doc__ = autoparallelize_docstring(sample_autopara_wrappable.__doc__, "Atoms")

--- a/wfl/generate/phonopy.py
+++ b/wfl/generate/phonopy.py
@@ -1,7 +1,7 @@
 import numpy as np
 from ase.atoms import Atoms
 
-from wfl.autoparallelize import _autoparallelize_ll
+from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 
 try:
     import phonopy
@@ -12,12 +12,6 @@ try:
     import phono3py
 except:
     phono3py = None
-
-
-def run(inputs, outputs, displacements, strain_displs, ph2_supercell, ph3_supercell=None, pair_cutoff=None, num_inputs_per_python_subprocess=10):
-    return _autoparallelize_ll(iterable=inputs, outputspec=outputs, op=run_autopara_wrappable, num_inputs_per_python_subprocess=num_inputs_per_python_subprocess, 
-                         displacements=displacements, strain_displs=strain_displs, ph2_supercell=ph2_supercell,
-                         ph3_supercell=ph3_supercell, pair_cutoff=pair_cutoff)
 
 
 def run_autopara_wrappable(atoms, displacements, strain_displs, ph2_supercell, ph3_supercell=None, pair_cutoff=None):
@@ -126,3 +120,9 @@ def run_autopara_wrappable(atoms, displacements, strain_displs, ph2_supercell, p
                     ats_pert[-1].append(at_pert)
 
     return ats_pert
+
+
+def run(*args, **kwargs):
+    return autoparallelize(run_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess":10}, **kwargs)
+run.__doc__ = autoparallelize_docstring(run_autopara_wrappable.__doc__, "Atoms")
+

--- a/wfl/generate/smiles.py
+++ b/wfl/generate/smiles.py
@@ -7,7 +7,7 @@ try:
 except ModuleNotFoundError:
     pass
 
-from wfl.autoparallelize import _autoparallelize_ll
+from wfl.autoparallelize import autoparallelize 
 
 
 def smi_to_atoms(smi, useBasicKnowledge=True, useExpTorsionAnglePrefs=True):
@@ -27,33 +27,6 @@ def smi_to_atoms(smi, useBasicKnowledge=True, useExpTorsionAnglePrefs=True):
     atoms = read(xyz_file, format='xyz')
     return atoms
 
-
-def run(outputs, smiles, useBasicKnowledge=True, useExpTorsionAnglePrefs=True, extra_info=None):
-    """Creates atomic configurations by repeatedly running smi_to_xyz, I/O with OutputSpec.
-
-    Parameters
-    ----------
-    outputs: OutputSpec
-        where to write outputs
-    smiles: str/list(str)
-       smiles string to generate structure from
-    useBasicKnowledge: bool, default True
-        impose basic knowledge such as flat aromatic rings
-    useExpTorsionAnglePrefs: bool, default True
-        impose experimental torsion angle preferences
-    extra_info: dict, default {}
-        extra fields to place into created atoms info dict
-
-    Returns
-    -------
-    ConfigSet corresponding to output
-
-    """
-
-    return _autoparallelize_ll(iterable=smiles, outputspec=outputs, op=run_autopara_wrappable,
-                         useBasicKnowledge=useBasicKnowledge,
-                         useExpTorsionAnglePrefs=useExpTorsionAnglePrefs,
-                         extra_info=extra_info)
 
 
 def run_autopara_wrappable(smiles, useBasicKnowledge=True, useExpTorsionAnglePrefs=True, extra_info=None):
@@ -91,3 +64,8 @@ def run_autopara_wrappable(smiles, useBasicKnowledge=True, useExpTorsionAnglePre
         atoms_list.append(at)
 
     return atoms_list
+
+
+def run(*args, **kwargs):
+    return autoparallelize(run_autopara_wrappable, *args, **kwargs)
+run.__doc__ = autoparallelize_docstring(run_autopara_wrappable.__doc__, "SMILES string")

--- a/wfl/generate/smiles.py
+++ b/wfl/generate/smiles.py
@@ -7,7 +7,7 @@ try:
 except ModuleNotFoundError:
     pass
 
-from wfl.autoparallelize import autoparallelize 
+from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 
 
 def smi_to_atoms(smi, useBasicKnowledge=True, useExpTorsionAnglePrefs=True):

--- a/wfl/generate/supercells.py
+++ b/wfl/generate/supercells.py
@@ -6,44 +6,8 @@ import numpy as np
 import spglib
 from ase.atoms import Atoms
 
-from wfl.autoparallelize import _autoparallelize_ll
+from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 from wfl.utils.find_voids import find_voids
-
-
-def largest_bulk(inputs, outputs, max_n_atoms, primitive=True, symprec=1.0e-3, num_inputs_per_python_subprocess=10):
-    return _autoparallelize_ll(iterable=inputs, outputspec=outputs, op=largest_bulk_autopara_wrappable,
-                         num_inputs_per_python_subprocess=num_inputs_per_python_subprocess, max_n_atoms=max_n_atoms, primitive=primitive, symprec=symprec)
-
-
-def vacancy(inputs, outputs, max_n_atoms, primitive=True, symprec=1.0e-3, n_vac=1, cluster_r=0.0, num_inputs_per_python_subprocess=10):
-    return _autoparallelize_ll(iterable=inputs, outputspec=outputs, op=vacancy_autopara_wrappable,
-                         num_inputs_per_python_subprocess=num_inputs_per_python_subprocess, max_n_atoms=max_n_atoms, primitive=primitive, symprec=symprec,
-                         n_vac=n_vac, cluster_r=cluster_r)
-
-def antisite(inputs, outputs, max_n_atoms, primitive=True, symprec=1.0e-3, n_antisite=1, cluster_r=0.0, num_inputs_per_python_subprocess=10):
-    return _autoparallelize_ll(iterable=inputs, outputspec=outputs, op=antisite_autopara_wrappable,
-                         num_inputs_per_python_subprocess=num_inputs_per_python_subprocess, max_n_atoms=max_n_atoms, primitive=primitive, symprec=symprec,
-                         n_antisite=n_antisite, cluster_r=cluster_r)
-
-
-def interstitial(inputs, outputs, max_n_atoms, interstitial_probability_radius_exponent=3.0,
-                 primitive=True, symprec=1.0e-3, num_inputs_per_python_subprocess=10):
-    return _autoparallelize_ll(iterable=inputs, outputspec=outputs, op=interstitial_autopara_wrappable,
-                         num_inputs_per_python_subprocess=num_inputs_per_python_subprocess, max_n_atoms=max_n_atoms,
-                         interstitial_probability_radius_exponent=interstitial_probability_radius_exponent,
-                         primitive=primitive, symprec=symprec)
-
-
-def surface(inputs, outputs, max_n_atoms, min_thickness, vacuum,
-            simple_cut=False, max_surface_cell_indices=1, duplicate_in_plane=True, pert=0.0,
-            primitive=True, symprec=1.0e-3, num_inputs_per_python_subprocess=10):
-    return _autoparallelize_ll(iterable=inputs, outputspec=outputs, op=surface_autopara_wrappable,
-                         num_inputs_per_python_subprocess=num_inputs_per_python_subprocess, max_n_atoms=max_n_atoms,
-                         min_thickness=min_thickness, vacuum=vacuum, simple_cut=simple_cut,
-                         max_surface_cell_indices=max_surface_cell_indices,
-                         duplicate_in_plane=duplicate_in_plane, pert=pert,
-                         primitive=primitive, symprec=symprec)
-
 
 def _get_primitive(at, symprec=1.0e-3):
     """get primitive cell corresponding to original lattice, copying original cell info and
@@ -155,6 +119,11 @@ def largest_bulk_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True
     return supercells
 
 
+def largest_bulk(*args, **kwargs):
+    return autoparallelize(largest_bulk_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+run.__doc__ = autoparallelize_docstring(largest_bulk_autopara_wrappable.__doc__, "Atoms")
+
+
 def vacancy_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, symprec=1.0e-3, n_vac=1, cluster_r=0.0):
     """make vacancies in largest bulk-like supercells
 
@@ -227,6 +196,11 @@ def vacancy_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, sym
         at.calc = None
         ####################################################################################################
     return supercells
+
+
+def vacancy(*args, **kwargs):
+    return autoparallelize(vacancy_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+run.__doc__ = autoparallelize_docstring(vacancy_autopara_wrappable.__doc__, "Atoms")
 
 
 def antisite_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, symprec=1.0e-3, n_antisite=1, cluster_r=0.0, Zs=None):
@@ -319,6 +293,11 @@ def antisite_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, sy
     return supercells
 
 
+def antisite(*args, **kwargs):
+    return autoparallelize(antisite_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+run.__doc__ = autoparallelize_docstring(antisite_autopara_wrappable.__doc__, "Atoms")
+
+
 def interstitial_autopara_wrappable(atoms, max_n_atoms, pert=0.0, interstitial_probability_radius_exponent=3.0, primitive=True,
                     symprec=1.0e-3):
     """make interstitials in largest bulk-like supercells
@@ -361,6 +340,11 @@ def interstitial_autopara_wrappable(atoms, max_n_atoms, pert=0.0, interstitial_p
         at.calc = None
         ####################################################################################################
     return supercells
+
+
+def interstitial(*args, **kwargs):
+    return autoparallelize(interstitial_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+run.__doc__ = autoparallelize_docstring(interstitial_autopara_wrappable.__doc__, "Atoms")
 
 
 def _are_lin_dep(v1, v2):
@@ -496,3 +480,8 @@ def surface_autopara_wrappable(atoms, max_n_atoms, min_thickness, vacuum, simple
         supercells.append(at)
 
     return supercells
+
+
+def surface(*args, **kwargs):
+    return autoparallelize(surface_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+run.__doc__ = autoparallelize_docstring(surface_autopara_wrappable.__doc__, "Atoms")

--- a/wfl/generate/supercells.py
+++ b/wfl/generate/supercells.py
@@ -121,7 +121,7 @@ def largest_bulk_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True
 
 def largest_bulk(*args, **kwargs):
     return autoparallelize(largest_bulk_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
-run.__doc__ = autoparallelize_docstring(largest_bulk_autopara_wrappable.__doc__, "Atoms")
+largest_bulk.__doc__ = autoparallelize_docstring(largest_bulk_autopara_wrappable.__doc__, "Atoms")
 
 
 def vacancy_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, symprec=1.0e-3, n_vac=1, cluster_r=0.0):
@@ -200,7 +200,7 @@ def vacancy_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, sym
 
 def vacancy(*args, **kwargs):
     return autoparallelize(vacancy_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
-run.__doc__ = autoparallelize_docstring(vacancy_autopara_wrappable.__doc__, "Atoms")
+vacancy.__doc__ = autoparallelize_docstring(vacancy_autopara_wrappable.__doc__, "Atoms")
 
 
 def antisite_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, symprec=1.0e-3, n_antisite=1, cluster_r=0.0, Zs=None):
@@ -295,7 +295,7 @@ def antisite_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, sy
 
 def antisite(*args, **kwargs):
     return autoparallelize(antisite_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
-run.__doc__ = autoparallelize_docstring(antisite_autopara_wrappable.__doc__, "Atoms")
+antisite.__doc__ = autoparallelize_docstring(antisite_autopara_wrappable.__doc__, "Atoms")
 
 
 def interstitial_autopara_wrappable(atoms, max_n_atoms, pert=0.0, interstitial_probability_radius_exponent=3.0, primitive=True,
@@ -344,7 +344,7 @@ def interstitial_autopara_wrappable(atoms, max_n_atoms, pert=0.0, interstitial_p
 
 def interstitial(*args, **kwargs):
     return autoparallelize(interstitial_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
-run.__doc__ = autoparallelize_docstring(interstitial_autopara_wrappable.__doc__, "Atoms")
+interstitial.__doc__ = autoparallelize_docstring(interstitial_autopara_wrappable.__doc__, "Atoms")
 
 
 def _are_lin_dep(v1, v2):
@@ -484,4 +484,4 @@ def surface_autopara_wrappable(atoms, max_n_atoms, min_thickness, vacuum, simple
 
 def surface(*args, **kwargs):
     return autoparallelize(surface_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
-run.__doc__ = autoparallelize_docstring(surface_autopara_wrappable.__doc__, "Atoms")
+surface.__doc__ = autoparallelize_docstring(surface_autopara_wrappable.__doc__, "Atoms")

--- a/wfl/generate/vib.py
+++ b/wfl/generate/vib.py
@@ -15,7 +15,7 @@ from scipy import stats
 
 from wfl.calculators import generic
 from wfl.configset import ConfigSet, OutputSpec
-from wfl.autoparallelize import _autoparallelize_ll
+from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 from wfl.utils.misc import atoms_to_list
 
 # conversion factor from eV/Å^2/amu to eV^2
@@ -570,16 +570,12 @@ def generate_normal_modes_autopara_wrappable(inputs, calculator, prop_prefix,
     return atoms_out
 
 
-def generate_normal_modes_parallel_atoms(inputs, outputs, calculator,
-                                         prop_prefix, num_inputs_per_python_subprocess=10):
-    # iterable loop parallelizes over input structures, not over 6xN
+def generate_normal_modes_parallel_atoms(*args, **kwargs):
+     # iterable loop parallelizes over input structures, not over 6xN
     # displaced structures needed for numerical hessian
-    parallel_hessian = False
-
-    return _autoparallelize_ll(iterable=inputs, outputspec=outputs,
-                         op=generate_normal_modes_autopara_wrappable, num_inputs_per_python_subprocess=num_inputs_per_python_subprocess,
-                         calculator=calculator, prop_prefix=prop_prefix,
-                         parallel_hessian=parallel_hessian)
+    kwargs["parallel_hessian"] = False 
+    return autoparallelize(generate_normal_modes_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+generate_normal_modes_parallel_atoms.__doc__ = autoparallelize_docstring(generate_normal_modes_autopara_wrappable.__doc__, "Atoms")
 
 
 def generate_normal_modes_parallel_hessian(inputs, outputs, calculator,

--- a/wfl/select/simple.py
+++ b/wfl/select/simple.py
@@ -7,30 +7,6 @@ from ase import Atoms
 from wfl.configset import ConfigSet
 from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 
-# def by_bool_func(inputs, outputs, at_filter):
-#     """apply a filter to a sequence of configs
-
-#     Parameters
-#     ----------
-#     inputs: ConfigSet
-#         input configurations
-#     outputs: OutputSpec
-#         corresponding output configurations
-#     at_filter: callable
-#         callable that takes an Atoms and returns a bool indicating if it should be selected
-
-#     Returns
-#     -------
-#     ConfigSet pointing to selected configurations
-#     """
-#     # disable parallelization by passing num_python_subprocesses=0
-#     if isinstance(at_filter, LambdaType) and at_filter.__name__ == "<lambda>":
-#         # turn of autoparallelization for lambdas, which cannot be pickled
-#         num_python_subprocesses = 0
-#     else:
-#         num_python_subprocesses = None
-#     return _autoparallelize_ll(num_python_subprocesses=num_python_subprocesses, iterable=inputs, outputspec=outputs, at_filter=at_filter, op=_select_autopara_wrappable)
-
 
 def _select_autopara_wrappable(inputs, at_filter):
     """apply a filter to a sequence of configs


### PR DESCRIPTION
Rewrite the parallelized functions that have been working with `_autoparallelize_ll` to instead use `autoparallelize`, following `generic.py` example. 