### PR TITLE
clean up autoparallelize wrapping docstring mangling

### DIFF
--- a/docs/source/overview.configset.rst
+++ b/docs/source/overview.configset.rst
@@ -17,6 +17,13 @@ Input and output of atomic structures
 ``ConfigSet`` can encapsulate one or multiple lists of ``ase.atoms.Atoms`` objects, or reference to stored sets of configuration in files (ABCD databases are currently unsupported). It can function as an iterator over all configs in the input, or iterate over groups of them according to the input definition with the ``ConfigSet().groups()`` method. The ``ConfigSet`` must be initialized with its input configurations, files, or other ``ConfigSet``s.
 
 ``OutputSpec`` works as the output layer, used for writing results during iterations, but the actual writing is not guaranteed to happen until the operation is closed with ``OutputSpec.close()``. It is possible to map a different output file to each input file, which will result in the outputs corresponding to each input file ending up in a different output file.
+
+Users should consult the simple example in :doc:`first_example`, or the documentation of the two classes at
+:meth:`wfl.configset.ConfigSet` and :meth:`wfl.configset.OutputSpec`
+
+==============================
+Internals, for developers
+==============================
  
 For example, to read from two files and write corresponding configs to two other files, use
 
@@ -46,7 +53,6 @@ storage).
 NOTE: the ABCD implementation is not currenly supported, but may be re-added if needed. The previous format is documented here for posterity
 
 .. code-block:: python
-
   
   s_in = ConfigSet(abcd_conn='mongodb://localhost:27017', input_queries={'input_tag' : 'necessary_input-val'})
   s_out = OutputSpec(abcd_conn='mongodb://localhost:27017', output_abcd=True, set_tags={'output_tag' : 'some unique value'})

--- a/examples/iterative_gap_fit/batch_gap_fit.py
+++ b/examples/iterative_gap_fit/batch_gap_fit.py
@@ -183,12 +183,14 @@ def get_descriptors(in_file, out_file, params_file, key='desc', **kwargs):
     params = yaml.safe_load(open(params_file, 'r'))
     params = [i for i in params if 'soap' in i.keys()]
 
+    per_atom = True
     for param in params:
         if 'average' not in param.keys():
             param['average'] = True
+            per_atom = False
 
     # Calculate the actual descriptors (gets added as key in at.info)
-    desc_calc(in_config, out_config, params, key, **kwargs)
+    desc_calc(in_config, out_config, params, key, per_atom, **kwargs)
     return None
 
 

--- a/examples/select_fps/fps.py
+++ b/examples/select_fps/fps.py
@@ -18,11 +18,13 @@ def main(nsamples):
     with open(os.path.join(workdir, 'gap_params.yaml'), 'r') as foo:
         desc_dict = yaml.safe_load(foo)
     desc_dicts = [d for d in desc_dict if 'soap' in d.keys()] # filtering out only SOAP descriptor
+    per_atom = True
     for param in desc_dicts:
         if 'average' not in param.keys():
             param['average']= True # to create global (per-conf) descriptors instead of local (per-atom)
+            per_atom = False
     
-    md_desc = calc_descriptors(inputs=md, outputs=md_desc, descs=desc_dicts, key='desc')
+    md_desc = calc_descriptors(inputs=md, outputs=md_desc, descs=desc_dicts, key='desc', per_atom=per_atom)
     
     # Step 2: Sampling
     fps     = OutputSpec(files=os.path.join(workdir, "out_fps.xyz"))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setuptools.setup(
     name="wfl",
     version="0.1.0b",
     packages=setuptools.find_packages(exclude=["tests"]),
-    install_requires=["click>=7.0", "numpy", "ase", "pyyaml", "spglib", "docstring_parser"
+    install_requires=["click>=7.0", "numpy", "ase", "pyyaml", "spglib", "docstring_parser",
                       "expyre-wfl @ https://github.com/libAtoms/ExPyRe/tarball/main",
                       "universalSOAP @ https://github.com/libAtoms/universalSOAP/tarball/main"],
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setuptools.setup(
     name="wfl",
     version="0.1.0b",
     packages=setuptools.find_packages(exclude=["tests"]),
-    install_requires=["click>=7.0", "numpy", "ase", "pyyaml", "spglib",
+    install_requires=["click>=7.0", "numpy", "ase", "pyyaml", "spglib", "docstring_parser"
                       "expyre-wfl @ https://github.com/libAtoms/ExPyRe/tarball/main",
                       "universalSOAP @ https://github.com/libAtoms/universalSOAP/tarball/main"],
     entry_points="""

--- a/tests/calculators/test_calc_generic.py
+++ b/tests/calculators/test_calc_generic.py
@@ -30,7 +30,7 @@ ref_morse_forces = np.array([[0., 0., 0.],
 
 
 def test_calculator_generic():
-    mol_out = generic.run_autopara_wrappable(molecule("CH4"), LennardJones(), properties=["energy", "forces"],
+    mol_out = generic._run_autopara_wrappable(molecule("CH4"), LennardJones(), properties=["energy", "forces"],
                              output_prefix="lj_dummy_")
     assert isinstance(mol_out, Atoms)
     assert "lj_dummy_energy" in mol_out.info.keys()
@@ -39,14 +39,14 @@ def test_calculator_generic():
 
 def test_name_auto():
     # LennardJones is the .__name__ in the calculator
-    mol_out = generic.run_autopara_wrappable(molecule("CH4"), LennardJones(), properties=["energy", "forces"], output_prefix="_auto_")
+    mol_out = generic._run_autopara_wrappable(molecule("CH4"), LennardJones(), properties=["energy", "forces"], output_prefix="_auto_")
     assert "LennardJones_energy" in mol_out.info.keys()
     assert mol_out.info["LennardJones_energy"] == approx(ref_lj_energy)
 
 
 def test_atoms_list():
     mol_in = [molecule("CH4"), molecule("CH3")]
-    mol_out = generic.run_autopara_wrappable(mol_in, LennardJones(), properties=["energy", "forces"],
+    mol_out = generic._run_autopara_wrappable(mol_in, LennardJones(), properties=["energy", "forces"],
                              output_prefix="_auto_")
     assert isinstance(mol_out, list)
     for at in mol_out:
@@ -63,7 +63,7 @@ def test_run(tmp_path):
 
 
 def test_default_properties():
-    mol_out = generic.run_autopara_wrappable(bulk("C"), EMT(), output_prefix="dummy_")
+    mol_out = generic._run_autopara_wrappable(bulk("C"), EMT(), output_prefix="dummy_")
 
     assert "dummy_energy" in mol_out.info.keys()
     assert "dummy_stress" in mol_out.info.keys()

--- a/tests/test_calc_descriptor.py
+++ b/tests/test_calc_descriptor.py
@@ -24,7 +24,8 @@ def test_calc_descriptor_average_any_atomic_number():
     ci = ConfigSet(ats)
 
     ats_desc = calc(ci, OutputSpec(),
-                    'soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 average n_species=2 species_Z={6 14}', 'desc')
+                    'soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 average n_species=2 species_Z={6 14}', 'desc',
+                    per_atom=False)
 
     d = Descriptor(
         'soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 average n_species=2 species_Z={6 14}').calc(ats[0])['data'][0]
@@ -44,14 +45,16 @@ def test_calc_descriptor_average_any_atomic_number_normalization():
 
     ats_desc = calc(ci, OutputSpec(), 
                     ['soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 average n_species=2 species_Z={6 14}', 
-                     'soap n_max=3 l_max=3 cutoff=5.0 atom_sigma=0.5 average n_species=2 species_Z={6 14}'], 'desc')
+                     'soap n_max=3 l_max=3 cutoff=5.0 atom_sigma=0.5 average n_species=2 species_Z={6 14}'], 'desc',
+                    per_atom=False)
 
     assert 1.0 == approx(np.linalg.norm(list(ats_desc)[0].info['desc']))
 
     ats[0].info.pop("desc", None)
     ats_desc = calc(ci, OutputSpec(),
                     ['soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 average n_species=2 species_Z={6 14}', 
-                     'soap n_max=3 l_max=3 cutoff=5.0 atom_sigma=0.5 average n_species=2 species_Z={6 14}'], 'desc', normalize=False)
+                     'soap n_max=3 l_max=3 cutoff=5.0 atom_sigma=0.5 average n_species=2 species_Z={6 14}'], 'desc', normalize=False,
+                    per_atom=False)
     assert np.sqrt(2) == approx(np.linalg.norm(list(ats_desc)[0].info['desc']))
 
 
@@ -62,7 +65,7 @@ def test_calc_descriptor_average_z_specific():
     descs = {6: 'soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 average Z=6 n_species=2 species_Z={6 14}',
              14: 'soap n_max=4 l_max=3 cutoff=5.0 atom_sigma=0.5 average Z=14 n_species=2 species_Z={6 14}'}
 
-    ats_desc = calc(ci, OutputSpec(), descs, 'desc')
+    ats_desc = calc(ci, OutputSpec(), descs, 'desc', per_atom=False)
 
     d6 = Descriptor(descs[6]).calc(ats[0])['data'][0]
     d14 = Descriptor(descs[14]).calc(ats[0])['data'][0]
@@ -85,7 +88,8 @@ def test_calc_descriptor_any_atomic_number():
     ci = ConfigSet(ats)
 
     ats_desc = calc(ci, OutputSpec(),
-                    'soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 n_species=2 species_Z={6 14}', 'desc', local=True)
+                    'soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 n_species=2 species_Z={6 14}', 'desc',
+                    per_atom=True)
 
     d = Descriptor(
         'soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 n_species=2 species_Z={6 14}').calc(ats[0])['data']
@@ -106,7 +110,8 @@ def test_calc_descriptor_any_atomic_number_normalization():
 
     ats_desc = calc(ci, OutputSpec(), 
                     ['soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 n_species=2 species_Z={6 14}', 
-                     'soap n_max=3 l_max=3 cutoff=5.0 atom_sigma=0.5 n_species=2 species_Z={6 14}'], 'desc', local=True)
+                     'soap n_max=3 l_max=3 cutoff=5.0 atom_sigma=0.5 n_species=2 species_Z={6 14}'], 'desc',
+                    per_atom=True)
 
     at = list(ats_desc)[0]
     assert 1.0 == approx(np.linalg.norm(at.arrays['desc'], axis=1))
@@ -115,7 +120,8 @@ def test_calc_descriptor_any_atomic_number_normalization():
 
     ats_desc = calc(ci, OutputSpec(), 
                     ['soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 n_species=2 species_Z={6 14}', 
-                     'soap n_max=3 l_max=3 cutoff=5.0 atom_sigma=0.5 n_species=2 species_Z={6 14}'], 'desc', local=True, normalize=False)
+                     'soap n_max=3 l_max=3 cutoff=5.0 atom_sigma=0.5 n_species=2 species_Z={6 14}'], 'desc',
+                    per_atom=True, normalize=False)
 
     at = list(ats_desc)[0]
     assert np.sqrt(2.0) == approx(np.linalg.norm(at.arrays['desc'], axis=1))
@@ -128,7 +134,7 @@ def test_calc_descriptor_z_specific():
     descs = {6: 'soap n_max=4 l_max=4 cutoff=5.0 atom_sigma=0.5 Z=6 n_species=2 species_Z={6 14}',
              14: 'soap n_max=4 l_max=3 cutoff=5.0 atom_sigma=0.5 Z=14 n_species=2 species_Z={6 14}'}
 
-    ats_desc = calc(ci, OutputSpec(), descs, 'desc', local=True)
+    ats_desc = calc(ci, OutputSpec(), descs, 'desc', per_atom=True)
 
     d6 = Descriptor(descs[6]).calc(ats[0])['data']
     d14 = Descriptor(descs[14]).calc(ats[0])['data']

--- a/tests/test_molecules.py
+++ b/tests/test_molecules.py
@@ -25,7 +25,7 @@ def test_smiles_run_autopara_wrappable():
     input_smiles = ['C', 'C(C)C']
     extra_info = {'config_type': 'testing', 'info_int': 5}
 
-    atoms = smiles.run_autopara_wrappable(input_smiles, extra_info=extra_info)
+    atoms = smiles._run_autopara_wrappable(input_smiles, extra_info=extra_info)
 
     for smi, at in zip(input_smiles, atoms):
 
@@ -37,7 +37,7 @@ def test_smiles_run_autopara_wrappable():
     input_smiles = 'C'
     extra_info = None
 
-    atoms = smiles.run_autopara_wrappable(input_smiles, extra_info)
+    atoms = smiles._run_autopara_wrappable(input_smiles, extra_info)
 
     assert len(atoms) == 1
     assert atoms[0].info['smiles'] == input_smiles

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -188,7 +188,7 @@ def test_subselect_from_traj(cu_slab):
 
     # returns full optimisation trajectories
     inputs = [cu_slab.copy(), cu_slab_optimised.copy()]
-    atoms_opt = optimize.run_autopara_wrappable(
+    atoms_opt = optimize._run_autopara_wrappable(
         inputs,
         calc,
         fmax=1e-2,
@@ -207,7 +207,7 @@ def test_subselect_from_traj(cu_slab):
 
     # returns [None] for unconverged and last config for converged otpimisation
     inputs = [cu_slab.copy(), cu_slab_optimised.copy()]
-    atoms_opt = optimize.run_autopara_wrappable(
+    atoms_opt = optimize._run_autopara_wrappable(
         inputs,
         calc,
         fmax=1e-2,

--- a/tests/test_select_greedy_fps.py
+++ b/tests/test_select_greedy_fps.py
@@ -128,7 +128,8 @@ def greedy_fps(calc_desc, tmp_path):
 
     ats_desc = calc_desc(ConfigSet(ats),
                          OutputSpec('test.select_greedy_FPS.desc.xyz', file_root=tmp_path),
-                         descs='soap n_max=4 l_max=4 cutoff=4.0 atom_sigma=0.25 average', key='desc')
+                         descs='soap n_max=4 l_max=4 cutoff=4.0 atom_sigma=0.25 average', key='desc',
+                         per_atom=False)
 
     print('try with desc in Atoms.info no exclude')
     np.random.seed(42)

--- a/tests/test_select_greedy_fps.py
+++ b/tests/test_select_greedy_fps.py
@@ -88,9 +88,9 @@ ref_array = np.array(
       2.71619185e-05, 0.00000000e+00]])
 
 
-def calc_desc_fake(configs_in, configs_out, descs, key):
+def calc_desc_fake(configs_in, configs_out, descs, key, per_atom):
     # fake descriptor calculator for envs with no quippy installed
-    if descs != "soap n_max=4 l_max=4 cutoff=4.0 atom_sigma=0.25 average":
+    if descs != "soap n_max=4 l_max=4 cutoff=4.0 atom_sigma=0.25 average" or per_atom:
         raise ValueError("pre-calculated descriptors are not for the given desc, fix your tests")
 
     for i, at in enumerate(configs_in):

--- a/wfl/autoparallelize/base.py
+++ b/wfl/autoparallelize/base.py
@@ -91,7 +91,7 @@ def autoparallelize_docstring(wrapped_func, wrappable_func, input_iterable_type,
     # add post to end
     for param_list in reversed(_autopara_docstring_params_post):
         param_list = [p.format(**{"input_iterable_type": input_iterable_type}) if isinstance(p, str) else p for p in param_list]
-        parsed.meta.insert(last_arg_i, docstring_parser.DocstringParam(*param_list))
+        parsed.meta.insert(last_arg_i + 1, docstring_parser.DocstringParam(*param_list))
 
     # find returns
     returns_i = None

--- a/wfl/autoparallelize/base.py
+++ b/wfl/autoparallelize/base.py
@@ -94,12 +94,16 @@ def autoparallelize_docstring(wrapped_func, wrappable_func, input_iterable_type,
         parsed.meta.insert(last_arg_i, docstring_parser.DocstringParam(*param_list))
 
     # find returns
+    returns_i = None
     for p_i, p in enumerate(parsed.meta):
         if isinstance(p, docstring_parser.DocstringReturns):
             returns_i = p_i
-
-    # replace returns
-    parsed.meta[returns_i] =  docstring_parser.DocstringReturns(*_autopara_docstring_returns)
+    if returns_i is not None:
+        # replace returns
+        parsed.meta[returns_i] =  docstring_parser.DocstringReturns(*_autopara_docstring_returns)
+    else:
+        # append returns
+        parsed.meta.append(docstring_parser.DocstringReturns(*_autopara_docstring_returns))
 
     wrapped_func.__doc__ = docstring_parser.compose(parsed)
 

--- a/wfl/calculators/generic.py
+++ b/wfl/calculators/generic.py
@@ -10,7 +10,7 @@ from wfl.utils.parallel import construct_calculator_picklesafe
 from .utils import save_results
 
 
-def run_autopara_wrappable(atoms, calculator, properties=None, output_prefix='_auto_', verbose=False, raise_calc_exceptions=False):
+def _run_autopara_wrappable(atoms, calculator, properties=None, output_prefix='_auto_', verbose=False, raise_calc_exceptions=False):
     """evaluates configs using an arbitrary calculator and store results in SinglePointCalculator
 
     Defaults to wfl_num_inputs_per_python_subprocess=10, to avoid recreating the calculator for
@@ -85,5 +85,5 @@ def run(*args, **kwargs):
 
     def_autopara_info = getattr(calculator, "wfl_generic_def_autopara_info", {"num_inputs_per_python_subprocess": 10})
 
-    return autoparallelize(run_autopara_wrappable, *args, def_autopara_info=def_autopara_info, **kwargs)
-run.__doc__ = autoparallelize_docstring(run_autopara_wrappable.__doc__, "Atoms")
+    return autoparallelize(_run_autopara_wrappable, *args, def_autopara_info=def_autopara_info, **kwargs)
+autoparallelize_docstring(run, _run_autopara_wrappable, "Atoms")

--- a/wfl/descriptors/quippy.py
+++ b/wfl/descriptors/quippy.py
@@ -12,7 +12,7 @@ from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 from wfl.utils.quip_cli_strings import dict_to_quip_str
 
 
-def from_any_to_Descriptor(descriptor_src, verbose=False):
+def _from_any_to_Descriptor(descriptor_src, verbose=False):
     """Create quippy.descriptors.Descriptor objects
 
     Parameters
@@ -71,7 +71,7 @@ def from_any_to_Descriptor(descriptor_src, verbose=False):
     return descs
 
 
-def calc_autopara_wrappable(atoms, descs, key, local=False, normalize=True, composition_weight=True, force=False, verbose=False):
+def _calc_autopara_wrappable(atoms, descs, key, local=False, normalize=True, composition_weight=True, force=False, verbose=False):
     """Calculate descriptor for each config or atom
 
     Parameters
@@ -102,7 +102,7 @@ def calc_autopara_wrappable(atoms, descs, key, local=False, normalize=True, comp
         Input configuration(s) with descriptors in info/arrays
     """
 
-    descs = from_any_to_Descriptor(descs, verbose=verbose)
+    descs = _from_any_to_Descriptor(descs, verbose=verbose)
 
     if isinstance(atoms, Atoms):
         at_list = [atoms]
@@ -197,6 +197,5 @@ def calc_autopara_wrappable(atoms, descs, key, local=False, normalize=True, comp
 
 
 def calc(*args, **kwargs):
-    return autoparallelize(calc_autopara_wrappable, *args, **kwargs)
-calc.__doc__ = autoparallelize_docstring(calc_autopara_wrappable.__doc__, "Atoms")
-
+    return autoparallelize(_calc_autopara_wrappable, *args, **kwargs)
+autoparallelize_docstring(calc, _calc_autopara_wrappable, "Atoms")

--- a/wfl/descriptors/quippy.py
+++ b/wfl/descriptors/quippy.py
@@ -3,10 +3,7 @@ from copy import deepcopy
 
 import numpy as np
 from ase.atoms import Atoms
-try:
-    from quippy.descriptors import Descriptor
-except ModuleNotFoundError:
-    pass
+from quippy.descriptors import Descriptor
 
 from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 from wfl.utils.quip_cli_strings import dict_to_quip_str

--- a/wfl/descriptors/quippy.py
+++ b/wfl/descriptors/quippy.py
@@ -3,7 +3,10 @@ from copy import deepcopy
 
 import numpy as np
 from ase.atoms import Atoms
-from quippy.descriptors import Descriptor
+try:
+    from quippy.descriptors import Descriptor
+except ModuleNotFoundError as exc:
+    raise RuntimeError("quippy.descriptors module not found, install with 'python3 -m pip install quippy-ase'")
 
 from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 from wfl.utils.quip_cli_strings import dict_to_quip_str

--- a/wfl/descriptors/quippy.py
+++ b/wfl/descriptors/quippy.py
@@ -12,7 +12,7 @@ from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 from wfl.utils.quip_cli_strings import dict_to_quip_str
 
 
-def _from_any_to_Descriptor(descriptor_src, verbose=False):
+def from_any_to_Descriptor(descriptor_src, verbose=False):
     """Create quippy.descriptors.Descriptor objects
 
     Parameters
@@ -102,7 +102,7 @@ def _calc_autopara_wrappable(atoms, descs, key, per_atom, normalize=True, compos
         Input configuration(s) with descriptors in info/arrays
     """
 
-    descs = _from_any_to_Descriptor(descs, verbose=verbose)
+    descs = from_any_to_Descriptor(descs, verbose=verbose)
 
     if isinstance(atoms, Atoms):
         at_list = [atoms]

--- a/wfl/descriptors/quippy.py
+++ b/wfl/descriptors/quippy.py
@@ -71,7 +71,7 @@ def _from_any_to_Descriptor(descriptor_src, verbose=False):
     return descs
 
 
-def _calc_autopara_wrappable(atoms, descs, key, local=False, normalize=True, composition_weight=True, force=False, verbose=False):
+def _calc_autopara_wrappable(atoms, descs, key, per_atom, normalize=True, composition_weight=True, force=False, verbose=False):
     """Calculate descriptor for each config or atom
 
     Parameters
@@ -81,16 +81,16 @@ def _calc_autopara_wrappable(atoms, descs, key, local=False, normalize=True, com
     descs: str / list(str) / dict(Z : str / Descriptor )
         descriptor or list of descriptors (applied to all species) or dict of descriptor string for each
         species (key None for all species)
-        If ``global``, combined descriptor will be concatenated.  If ``local`` and ``Z`` is not None, multiple arrays
+        If ``not per_atom``, combined descriptor will be concatenated.  If ``per_atom`` and ``Z`` is not None, multiple arrays
         entries will be created, one per Zcenter, named <key>_Z_<Zcenter>.
     key: str
-        key in Atoms.info (global) or Atoms.arrays (local) to store information
-    local: bool, default False
+        key in Atoms.info (``not per_atom``) or Atoms.arrays (``per_atom``) to store information
+    per_atom: bool
         calculate a local (per-atom) descriptor, as opposed to global (per-config)
     normalize: bool, default True
         normalize final vector (e.g. if contributions from multiple descriptors were concatenated)
     composition_weight: bool, default True
-        when concatenating contributions from different species for a global, weight each by composition fraction
+        when concatenating contributions from different species for a per-config, weight each by composition fraction
     force: bool, default False
         overwrite key if already exists
     verbose: bool, default False
@@ -110,7 +110,7 @@ def _calc_autopara_wrappable(atoms, descs, key, local=False, normalize=True, com
         at_list = atoms
 
     # local and global share very little code - should be two functions?
-    if local:
+    if per_atom:
         for at in at_list:
             # check for existing key with optional _Z_<Z> suffix
             matches = [re.search(f'^{key}(_Z_[0-9]+)?$', k) for k in at.arrays]
@@ -136,7 +136,7 @@ def _calc_autopara_wrappable(atoms, descs, key, local=False, normalize=True, com
                     if Zcenter is None:
                         # applies to all species
                         if desc_vec.shape[0] != len(at):
-                            raise RuntimeError(('Requested local descriptor that applies to all species but '
+                            raise RuntimeError(('Requested per_atom descriptor that applies to all species but '
                                                 'data.shape[0] {} != len(at) == {}').format(desc_vec.shape[0], len(at)))
                         use_desc_vec = desc_vec
                     else:

--- a/wfl/generate/buildcell.py
+++ b/wfl/generate/buildcell.py
@@ -127,7 +127,7 @@ def conv_buildcell_out(buildcell_output):
 
 
 
-def run_autopara_wrappable(config_is, buildcell_cmd, buildcell_input, extra_info=None,
+def _run_autopara_wrappable(config_is, buildcell_cmd, buildcell_input, extra_info=None,
            perturbation=0.0, skip_failures=True, symprec=0.01, verbose=False):
     """Creates atomic configurations by repeatedly running buildcell
 
@@ -208,5 +208,5 @@ def run_autopara_wrappable(config_is, buildcell_cmd, buildcell_input, extra_info
     return atoms_list
 
 def run(*args, **kwargs):
-    return autoparallelize(run_autopara_wrappable, *args, **kwargs)
-run.__doc__ = autoparallelize_docstring(run_autopara_wrappable.__doc__, "Atoms")
+    return autoparallelize(_run_autopara_wrappable, *args, **kwargs)
+autoparallelize_docstring(run, _run_autopara_wrappable, "Atoms")

--- a/wfl/generate/md/__init__.py
+++ b/wfl/generate/md/__init__.py
@@ -18,7 +18,7 @@ from ..utils import config_type_append
 bar = 1.0e-4 * GPa
 
 
-def sample_autopara_wrappable(atoms, calculator, steps, dt, temperature=None, temperature_tau=None,
+def _sample_autopara_wrappable(atoms, calculator, steps, dt, temperature=None, temperature_tau=None,
               pressure=None, pressure_tau=None, compressibility_fd_displ=0.01,
               traj_step_interval=1, skip_failures=True, results_prefix='md_', verbose=False, update_config_type=True,
               traj_select_during_func=None, traj_select_after_func=None, abort_check=None):
@@ -249,8 +249,6 @@ def sample(*args, **kwargs):
         initializer = (np.random.seed, [])
     def_autopara_info={"initializer":initializer}
 
-    return autoparallelize(sample_autopara_wrappable, *args, 
+    return autoparallelize(_sample_autopara_wrappable, *args, 
         def_autopara_info=def_autopara_info, **kwargs)
-sample.__doc__ = autoparallelize_docstring(sample_autopara_wrappable.__doc__, "Atoms")
-
-
+autoparallelize_docstring(sample, _sample_autopara_wrappable, "Atoms")

--- a/wfl/generate/minimahopping.py
+++ b/wfl/generate/minimahopping.py
@@ -14,7 +14,7 @@ from wfl.utils.parallel import construct_calculator_picklesafe
 
 
 # perform MinimaHopping on one ASE.atoms object
-def atom_opt_hopping(atom, calculator, Ediff0, T0, minima_threshold, mdmin,
+def _atom_opt_hopping(atom, calculator, Ediff0, T0, minima_threshold, mdmin,
                      fmax, timestep, totalsteps, skip_failures, **opt_kwargs):
     workdir = os.getcwd()
     rundir = tempfile.mkdtemp(dir=workdir, prefix='Opt_hopping_')
@@ -44,7 +44,7 @@ def atom_opt_hopping(atom, calculator, Ediff0, T0, minima_threshold, mdmin,
         return traj
 
 
-def run_autopara_wrappable(atoms, calculator, Ediff0=1, T0=1000, minima_threshold=0.5, mdmin=2,
+def _run_autopara_wrappable(atoms, calculator, Ediff0=1, T0=1000, minima_threshold=0.5, mdmin=2,
                            fmax=1, timestep=1, totalsteps=10, skip_failures=True, **opt_kwargs):
     """runs a structure optimization
 
@@ -82,9 +82,9 @@ def run_autopara_wrappable(atoms, calculator, Ediff0=1, T0=1000, minima_threshol
     all_trajs = []
 
     for at in atoms_to_list(atoms):
-        traj = atom_opt_hopping(atom=at, calculator=calculator, Ediff0=Ediff0, T0=T0, minima_threshold=minima_threshold,
-                                mdmin=mdmin, fmax=fmax, timestep=timestep, totalsteps=totalsteps,
-                                skip_failures=skip_failures, **opt_kwargs)
+        traj = _atom_opt_hopping(atom=at, calculator=calculator, Ediff0=Ediff0, T0=T0, minima_threshold=minima_threshold,
+                                 mdmin=mdmin, fmax=fmax, timestep=timestep, totalsteps=totalsteps,
+                                 skip_failures=skip_failures, **opt_kwargs)
         all_trajs.append(traj)
 
     return all_trajs
@@ -102,8 +102,8 @@ def run(*args, **kwargs):
     def_autopara_info = {"initializer": initializer, "num_inputs_per_python_subprocess": 10,
                          "hash_ignore": ["initializer"]}
 
-    return autoparallelize(run_autopara_wrappable, *args,
+    return autoparallelize(_run_autopara_wrappable, *args,
                            def_autopara_info=def_autopara_info, **kwargs)
 
 
-run.__doc__ = autoparallelize_docstring(run_autopara_wrappable.__doc__, "Atoms")
+autoparallelize_docstring(run, _run_autopara_wrappable, "Atoms")

--- a/wfl/generate/optimize.py
+++ b/wfl/generate/optimize.py
@@ -17,7 +17,7 @@ from .utils import config_type_append
 orig_log = PreconLBFGS.log
 
 
-def new_log(self, forces=None):
+def _new_log(self, forces=None):
     if 'buildcell_config_i' in self.atoms.info:
         if self.logfile is not None:
             self.logfile.write(str(self.atoms.info['buildcell_config_i']) + ' ')
@@ -29,11 +29,11 @@ def new_log(self, forces=None):
         pass
 
 
-PreconLBFGS.log = new_log
+PreconLBFGS.log = _new_log
 
 
 
-def run_autopara_wrappable(atoms, calculator, fmax=1.0e-3, smax=None, steps=1000, pressure=None,
+def _run_autopara_wrappable(atoms, calculator, fmax=1.0e-3, smax=None, steps=1000, pressure=None,
            keep_symmetry=True, traj_step_interval=1, traj_subselect=None, skip_failures=True,
            results_prefix='optimize_', verbose=False, update_config_type=True, **opt_kwargs):
     """runs a structure optimization 
@@ -206,9 +206,9 @@ def run(*args, **kwargs):
     def_autopara_info={"initializer":initializer, "num_inputs_per_python_subprocess":10,
             "hash_ignore":["initializer"]}
 
-    return autoparallelize(run_autopara_wrappable, *args, 
+    return autoparallelize(_run_autopara_wrappable, *args, 
         def_autopara_info=def_autopara_info, **kwargs)
-run.__doc__ = autoparallelize_docstring(run_autopara_wrappable.__doc__, "Atoms")
+autoparallelize_docstring(run, _run_autopara_wrappable, "Atoms")
 
 
 

--- a/wfl/generate/phonopy.py
+++ b/wfl/generate/phonopy.py
@@ -14,7 +14,7 @@ except ModuleNotFoundError:
     phono3py = None
 
 
-def run_autopara_wrappable(atoms, displacements, strain_displs, ph2_supercell, ph3_supercell=None, pair_cutoff=None):
+def _run_autopara_wrappable(atoms, displacements, strain_displs, ph2_supercell, ph3_supercell=None, pair_cutoff=None):
     """create displaced configs with phonopy or phono3py for each structure in inputs
 
     Parameters
@@ -123,6 +123,6 @@ def run_autopara_wrappable(atoms, displacements, strain_displs, ph2_supercell, p
 
 
 def run(*args, **kwargs):
-    return autoparallelize(run_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess":10}, **kwargs)
-run.__doc__ = autoparallelize_docstring(run_autopara_wrappable.__doc__, "Atoms")
+    return autoparallelize(_run_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess":10}, **kwargs)
+autoparallelize_docstring(run, _run_autopara_wrappable, "Atoms")
 

--- a/wfl/generate/smiles.py
+++ b/wfl/generate/smiles.py
@@ -29,7 +29,7 @@ def smi_to_atoms(smi, useBasicKnowledge=True, useExpTorsionAnglePrefs=True):
 
 
 
-def run_autopara_wrappable(smiles, useBasicKnowledge=True, useExpTorsionAnglePrefs=True, extra_info=None):
+def _run_autopara_wrappable(smiles, useBasicKnowledge=True, useExpTorsionAnglePrefs=True, extra_info=None):
     """Creates atomic configurations by repeatedly running smi_to_xyz, I/O with OutputSpec.
 
     Parameters
@@ -67,5 +67,5 @@ def run_autopara_wrappable(smiles, useBasicKnowledge=True, useExpTorsionAnglePre
 
 
 def run(*args, **kwargs):
-    return autoparallelize(run_autopara_wrappable, *args, **kwargs)
-run.__doc__ = autoparallelize_docstring(run_autopara_wrappable.__doc__, "SMILES string")
+    return autoparallelize(_run_autopara_wrappable, *args, **kwargs)
+autoparallelize_docstring(run, _run_autopara_wrappable, "SMILES string")

--- a/wfl/generate/supercells.py
+++ b/wfl/generate/supercells.py
@@ -149,7 +149,7 @@ def _vacancy_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, sy
     -------
         list(Atoms) supercells with vacancies
     """
-    supercells = largest_bulk_autopara_wrappable(atoms, max_n_atoms, primitive=primitive, symprec=symprec)
+    supercells = _largest_bulk_autopara_wrappable(atoms, max_n_atoms, primitive=primitive, symprec=symprec)
     for at in supercells:
         if len(at) <= n_vac:
             # should this be an error?
@@ -230,7 +230,7 @@ def _antisite_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, s
     -------
         list(Atoms) supercells with antisites
     """
-    supercells = largest_bulk_autopara_wrappable(atoms, max_n_atoms, primitive=primitive, symprec=symprec)
+    supercells = _largest_bulk_autopara_wrappable(atoms, max_n_atoms, primitive=primitive, symprec=symprec)
     for at in supercells:
         if len(at) <= n_antisite:
             # should this be an error?
@@ -321,7 +321,7 @@ def _interstitial_autopara_wrappable(atoms, max_n_atoms, pert=0.0, interstitial_
     -------
         list(Atoms) supercells with interstitials
     """
-    supercells = largest_bulk_autopara_wrappable(atoms, max_n_atoms, primitive=primitive, symprec=symprec)
+    supercells = _largest_bulk_autopara_wrappable(atoms, max_n_atoms, primitive=primitive, symprec=symprec)
     for at in supercells:
         voids = np.asarray(find_voids(at))
         p_raw = voids[:, 0] ** interstitial_probability_radius_exponent

--- a/wfl/generate/supercells.py
+++ b/wfl/generate/supercells.py
@@ -72,7 +72,7 @@ def _largest_isotropic_supercell(at, max_n_atoms, vary_cell_vectors=None):
 
 
 # try ase.build.supercells.find_optimal_cell_shape ?
-def largest_bulk_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, symprec=1.0e-3):
+def _largest_bulk_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, symprec=1.0e-3):
     """make largest bulk-like supercells
 
     Parameters
@@ -120,11 +120,11 @@ def largest_bulk_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True
 
 
 def largest_bulk(*args, **kwargs):
-    return autoparallelize(largest_bulk_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
-largest_bulk.__doc__ = autoparallelize_docstring(largest_bulk_autopara_wrappable.__doc__, "Atoms")
+    return autoparallelize(_largest_bulk_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+autoparallelize_docstring(largest_bulk, _largest_bulk_autopara_wrappable, "Atoms")
 
 
-def vacancy_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, symprec=1.0e-3, n_vac=1, cluster_r=0.0):
+def _vacancy_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, symprec=1.0e-3, n_vac=1, cluster_r=0.0):
     """make vacancies in largest bulk-like supercells
 
     Parameters
@@ -199,11 +199,11 @@ def vacancy_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, sym
 
 
 def vacancy(*args, **kwargs):
-    return autoparallelize(vacancy_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
-vacancy.__doc__ = autoparallelize_docstring(vacancy_autopara_wrappable.__doc__, "Atoms")
+    return autoparallelize(_vacancy_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+autoparallelize_docstring(vacancy, _vacancy_autopara_wrappable, "Atoms")
 
 
-def antisite_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, symprec=1.0e-3, n_antisite=1, cluster_r=0.0, Zs=None):
+def _antisite_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, symprec=1.0e-3, n_antisite=1, cluster_r=0.0, Zs=None):
     """make antisites in largest bulk-like supercells
 
     Parameters
@@ -294,11 +294,11 @@ def antisite_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, sy
 
 
 def antisite(*args, **kwargs):
-    return autoparallelize(antisite_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
-antisite.__doc__ = autoparallelize_docstring(antisite_autopara_wrappable.__doc__, "Atoms")
+    return autoparallelize(_antisite_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+autoparallelize_docstring(antisite, _antisite_autopara_wrappable, "Atoms")
 
 
-def interstitial_autopara_wrappable(atoms, max_n_atoms, pert=0.0, interstitial_probability_radius_exponent=3.0, primitive=True,
+def _interstitial_autopara_wrappable(atoms, max_n_atoms, pert=0.0, interstitial_probability_radius_exponent=3.0, primitive=True,
                     symprec=1.0e-3):
     """make interstitials in largest bulk-like supercells
 
@@ -343,15 +343,15 @@ def interstitial_autopara_wrappable(atoms, max_n_atoms, pert=0.0, interstitial_p
 
 
 def interstitial(*args, **kwargs):
-    return autoparallelize(interstitial_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
-interstitial.__doc__ = autoparallelize_docstring(interstitial_autopara_wrappable.__doc__, "Atoms")
+    return autoparallelize(_interstitial_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+autoparallelize_docstring(interstitial, _interstitial_autopara_wrappable, "Atoms")
 
 
 def _are_lin_dep(v1, v2):
     return np.abs(np.abs(np.dot(v1, v2)) - np.linalg.norm(v1) * np.linalg.norm(v2)) < 1.0e-10
 
 
-def surface_autopara_wrappable(atoms, max_n_atoms, min_thickness, vacuum, simple_cut=False, max_surface_cell_indices=1,
+def _surface_autopara_wrappable(atoms, max_n_atoms, min_thickness, vacuum, simple_cut=False, max_surface_cell_indices=1,
                duplicate_in_plane=True, pert=0.0,
                primitive=True, symprec=1.0e-3):
     """make surface supercells
@@ -483,5 +483,5 @@ def surface_autopara_wrappable(atoms, max_n_atoms, min_thickness, vacuum, simple
 
 
 def surface(*args, **kwargs):
-    return autoparallelize(surface_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
-surface.__doc__ = autoparallelize_docstring(surface_autopara_wrappable.__doc__, "Atoms")
+    return autoparallelize(_surface_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+autoparallelize_docstring(surface, _surface_autopara_wrappable, "Atoms")

--- a/wfl/generate/vib.py
+++ b/wfl/generate/vib.py
@@ -537,7 +537,7 @@ def sample_normal_modes(inputs, outputs, temp, sample_size, prop_prefix,
     outputs.close()
 
 
-def generate_normal_modes_autopara_wrappable(inputs, calculator, prop_prefix,
+def _generate_normal_modes_autopara_wrappable(inputs, calculator, prop_prefix,
                              parallel_hessian):
     """Get normal mode information for all atoms in the input
 
@@ -574,8 +574,8 @@ def generate_normal_modes_parallel_atoms(*args, **kwargs):
      # iterable loop parallelizes over input structures, not over 6xN
     # displaced structures needed for numerical hessian
     kwargs["parallel_hessian"] = False 
-    return autoparallelize(generate_normal_modes_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
-generate_normal_modes_parallel_atoms.__doc__ = autoparallelize_docstring(generate_normal_modes_autopara_wrappable.__doc__, "Atoms")
+    return autoparallelize(_generate_normal_modes_autopara_wrappable, *args, def_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+autoparallelize_docstring(generate_normal_modes_parallel_atoms, _generate_normal_modes_autopara_wrappable, "Atoms")
 
 
 def generate_normal_modes_parallel_hessian(inputs, outputs, calculator,

--- a/wfl/generate/vib.py
+++ b/wfl/generate/vib.py
@@ -393,7 +393,7 @@ class Vibrations:
                 displaced_ats=displaced_out_configset.output_configs)
 
         else:
-            displaced_out_atoms = generic.run_autopara_wrappable(atoms=displaced_in_configset,
+            displaced_out_atoms = generic._run_autopara_wrappable(atoms=displaced_in_configset,
                                              calculator=calculator,
                                              properties=properties,
                                              output_prefix=self.prop_prefix)
@@ -581,7 +581,7 @@ autoparallelize_docstring(generate_normal_modes_parallel_atoms, _generate_normal
 def generate_normal_modes_parallel_hessian(inputs, outputs, calculator,
                                            prop_prefix):
     parallel_hessian = True
-    atoms_out = generate_normal_modes_autopara_wrappable(inputs=inputs,
+    atoms_out = _generate_normal_modes_autopara_wrappable(inputs=inputs,
                                          calculator=calculator,
                                          prop_prefix=prop_prefix,
                                          parallel_hessian=parallel_hessian)

--- a/wfl/select/simple.py
+++ b/wfl/select/simple.py
@@ -17,8 +17,6 @@ def _select_autopara_wrappable(inputs, at_filter):
         input configurations
     at_filter: callable
         callable that takes an Atoms and returns a bool indicating if it should be selected
-
-
     """
     outputs = []
     for at in inputs:
@@ -35,10 +33,10 @@ def by_bool_func(*args, **kwargs):
         num_python_subprocesses = 0
     else:
         num_python_subprocesses = None
-    def_autopara_info={"num_python_subprocesses":num_python_subprocesses}
+    def_autopara_info={"num_python_subprocesses": num_python_subprocesses}
     return autoparallelize(_select_autopara_wrappable, *args,
            def_autopara_info=def_autopara_info, **kwargs)
-by_bool_func.__doc__ = autoparallelize_docstring(_select_autopara_wrappable.__doc__, "Atoms")
+autoparallelize_docstring(by_bool_func, _select_autopara_wrappable, "Atoms")
 
 # NOTE this could probably be done with autoparallelize by returning a list with multiple
 # copies when a single config needs to be returned multiple times, and either


### PR DESCRIPTION
Much cleaner autoparallelize-wrapped docstring with `docstring_parse`. Just `wfl.descriptors.quippy.calc` so far.

Also clean up some `descriptors.quippy.calc()` syntax

closs #159 