### PR TITLE
Try a workaround for missing syntax highlighting in nbsphinx redered notebook

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,8 @@ extensions = ['sphinx.ext.autodoc',
 			  'sphinx.ext.napoleon',
 			  'sphinx_click.ext',
                           'nbsphinx',
-			  'myst_parser'
+			  'myst_parser',
+                          'IPython.sphinxext.ipython_console_highlighting'
 				]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
See https://github.com/spatialaudio/nbsphinx/issues/24#issuecomment-187172022