### PR TITLE
Add a remote_label to the Vasp evaluation call in `gap_rss_iter_fit.py`.

### DIFF
--- a/wfl/cli/gap_rss_iter_fit.py
+++ b/wfl/cli/gap_rss_iter_fit.py
@@ -375,7 +375,8 @@ def evaluate_ref(dft_in_configs, dft_evaluated_configs, params, run_dir, verbose
         inputs=dft_in_configs,
         outputs=dft_evaluated_configs,
         calculator=calculator(workdir=run_dir, keep_files=keep_files, **params.dft_params.get("kwargs", {})),
-        output_prefix="REF_"
+        output_prefix="REF_",
+        autopara_info = {'remote_label': 'REF_eval'}
     )
 
 


### PR DESCRIPTION
Now that DFT evaluations are just done using `generic.run`, it's harder to specify their `RemoteInfo` from an env var with a dict key that points to the call stack and still distinguish them from other calls to `generic.run`, because more of the tail end of the call stack is identical. As a result, it's more useful to have (unique) remote_label arguments to the egeneric.run` calls that do the DFT evaluations, so add one to `gap_rss_iter_fit.py`.