### PR TITLE
Use full operation name when reporting autoparallelize status

### DIFF
--- a/wfl/autoparallelize/base.py
+++ b/wfl/autoparallelize/base.py
@@ -3,6 +3,8 @@ import os
 import warnings
 import re
 import docstring_parser
+import inspect
+
 
 from wfl.configset import ConfigSet, OutputSpec
 from .pool import do_in_pool
@@ -231,7 +233,8 @@ def _autoparallelize_ll(num_python_subprocesses, num_inputs_per_python_subproces
         if not isinstance(outputspec, OutputSpec):
             raise RuntimeError(f'autoparallelize requires outputspec be None or OutputSpec, got {type(outputspec)}')
         if outputspec.done():
-            sys.stderr.write(f'Returning before {op} since output is done\n')
+            op_full_name = inspect.getmodule(op).__name__ + "." + op.__name__
+            sys.stderr.write(f'Returning before {op_full_name} since output is done\n')
             return outputspec.to_ConfigSet()
 
     if remote_info is not None:


### PR DESCRIPTION
Have a better description than 
```
Returning before <function _sample_autopara_wrappable at 0x7f8e44077820> since output is done
```
Follows the "Running" reporting of operation name:
```
Running wfl.calculators.generic._run_autopara_wrappable with num_python_subprocesses=2, num_inputs_per_python_subprocess=10
```