### PR TITLE
Autopara per item info

### DIFF
--- a/complete_pytest.tin
+++ b/complete_pytest.tin
@@ -4,7 +4,9 @@ module purge
 module load compiler/gnu python/system python_extras/quippy
 
 # should include both tin and tin_ssh - not as good as real remote machine, but maybe close enough
-export EXPYRE_PYTEST_SYSTEMS='tin'
+if [ -z $EXPYRE_PYTEST_SYSTEMS ]; then
+    export EXPYRE_PYTEST_SYSTEMS='tin'
+fi
 
 echo  "GIT VERSION " $( git describe --always --tags --dirty ) > complete_pytest.tin.out 
 echo "" >> complete_pytest.tin.out 

--- a/docs/source/examples.daisy_chain_mlip_fitting.ipynb
+++ b/docs/source/examples.daisy_chain_mlip_fitting.ipynb
@@ -55,13 +55,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
-    "from ase.io import read, write\n",
     "from ase import Atoms\n",
     "\n",
     "from xtb.ase.calculator import XTB\n",
@@ -88,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -96,9 +95,10 @@
    "source": [
     "# set random seed, so that MD runs, etc are reproducible and we can check for RMSEs. \n",
     "# this cell is hidden from tutorials. \n",
-    "np.random.seed(20230301)\n",
     "import os\n",
-    "os.environ[\"WFL_DETERMINISTIC_HACK\"] = \"True\""
+    "random_seed = 20230301\n",
+    "np.random.seed(random_seed)\n",
+    "os.environ[\"WFL_DETERMINISTIC_HACK\"] = \"1\""
    ]
   },
   {
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,6 +193,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# regenerate smiles_confgis with a random seed set for testing purposes\n",
+    "# this cell is hidden from docs. \n",
+    "\n",
+    "outputs = OutputSpec(\"1.ch.rdkit.xyz\", overwrite=True)\n",
+    "smiles_configs = smiles.run(all_smiles, outputs=outputs, randomSeed=random_seed)"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -204,9 +217,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Creating job md_chunk_0\n",
+      "ExPyRe md_chunk_0 constructor done stage in files 1678315110.891046\n",
+      "Starting job for md_chunk_0_rUdPf-6O8v8oGgIhZlbTarUFcD5475ePRFLimtjN-4c=_hosoi20l\n",
+      "Gathering results for md_chunk_0_rUdPf-6O8v8oGgIhZlbTarUFcD5475ePRFLimtjN-4c=_hosoi20l remote 207345\n",
+      "Waiting for job md_chunk_0_rUdPf-6O8v8oGgIhZlbTarUFcD5475ePRFLimtjN-4c=_hosoi20l up to 3600 s: \n",
+      "qrrr\n",
+      "Running wfl.generate.md._sample_autopara_wrappable with num_python_subprocesses=4, num_inputs_per_python_subprocess=1\n"
+     ]
+    }
+   ],
    "source": [
     "outputs = OutputSpec(\"2.ch.rdkit.md.traj.xyz\")\n",
     "\n",
@@ -217,16 +244,18 @@
     "    \"temperature_tau\": 500,  \n",
     "    \"results_prefix\": \"xtb_\",\n",
     "    \"traj_step_interval\": 5}\n",
-    "    \n",
     "remote_info = {\n",
-    "    \"sys_name\" : \"github\", \n",
+    "    \"sys_name\" : \"local\", \n",
     "    \"job_name\" : \"md\", \n",
     "    \"resources\" : { \n",
     "        \"max_time\" : \"15m\",\n",
-    "        \"num_cores\" : 2,\n",
-    "        \"partitions\" : \"standard\"}, \n",
+    "        \"num_cores\" : 4,\n",
+    "        \"partitions\" : \"any$\"}, \n",
+    "    \"partial_node\": True,\n",
     "    \"check_interval\": 5,\n",
     "    \"num_inputs_per_queued_job\" :20,\n",
+    "    \"pre_cmds\" :[\"conda activate dev\"],\n",
+    "    \"env_vars\": [\"WFL_DETERMINISTIC_HACK=1\"]\n",
     "}\n",
     "\n",
     "md_sample = md.sample(\n",
@@ -234,7 +263,9 @@
     "    outputs=outputs,\n",
     "    calculator=xtb_calc,\n",
     "    autopara_info = AutoparaInfo(\n",
-    "        remote_info=remote_info),\n",
+    "        # remote_info=remote_info\n",
+    "        num_python_subprocesses=2\n",
+    "        ),\n",
     "    **md_params\n",
     "    )\n"
    ]
@@ -251,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,12 +467,24 @@
     "        \"num_cores\" : 2,\n",
     "        \"partitions\" : \"standard\"}, \n",
     "    \"check_interval\": 5, \n",
+    "}\n",
+    "remote_info = {\n",
+    "    \"sys_name\" : \"local\", \n",
+    "    \"job_name\" : \"md\", \n",
+    "    \"resources\" : { \n",
+    "        \"max_time\" : \"15m\",\n",
+    "        \"num_cores\" : 4,\n",
+    "        \"partitions\" : \"any$\"}, \n",
+    "    \"partial_node\": True,\n",
+    "    \"check_interval\": 5,\n",
+    "    \"num_inputs_per_queued_job\" :20,\n",
+    "    \"pre_cmds\" :[\"conda activate dev\"]\n",
     "}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -450,14 +493,63 @@
     "# set to None for github testing purposes\n",
     "# This cell is hidden from being rendered in the docs. \n",
     "# remote_info = None\n",
-    "gap_params[\"rnd_seed\"] = 20230301"
+    "gap_params[\"rnd_seed\"] = random_seed "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ExPyRe md constructor done stage in files 1678315145.4742718\n",
+      "Waiting for job md_v1KN9m9dA_vDclpSFPAZ-Cc0fn0qZk4vvZweDkcEwf0=_nexiodo6 up to 3600 s: \n",
+      "qqqr\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fitting command:\n",
+      " gap_fit gap_file=_gap.xml energy_parameter_name=xtb_energy force_parameter_name=xtb_forces default_sigma={0.001 0.01 0.0 0.0} config_type_kernel_regularisation=isolated_atom:0.0001:0.0001:0.0:0.0 rnd_seed=20230301 atoms_filename=/tmp/207346.1.any/_GAP_fitting_configs.jvsejeks.xyz gap={ soap=T l_max=3 n_max=6 cutoff=3 delta=0.1 covariance_type=dot_product zeta=4 n_sparse=20 sparse_method=cur_points atom_gaussian_width=0.3 cutoff_transition_width=0.5 : soap=T l_max=3 n_max=6 cutoff=6 delta=0.1 covariance_type=dot_product zeta=4 n_sparse=20 sparse_method=cur_points atom_gaussian_width=0.6 cutoff_transition_width=1 : distance_2b=T cutoff=7 covariance_type=ard_se delta=1 theta_uniform=1.0 sparse_method=uniform n_sparse=10 } 2>&1 > _gap_fit.out \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "copying _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9551 gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9551\n",
+      "copying _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9552 gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9552\n",
+      "copying _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9553 gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9553\n",
+      "copying _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9554 gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9554\n",
+      "copying _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9555 gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9555\n",
+      "copying _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9556 gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9556\n",
+      "copying _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9557 gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9557\n",
+      "Deleting _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9551\n",
+      "Deleting _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9552\n",
+      "Deleting _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9553\n",
+      "Deleting _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9554\n",
+      "Deleting _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9555\n",
+      "Deleting _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9556\n",
+      "Deleting _gap.xml.sparseX.GAP_2023_3_8_0_22_39_29_9557\n",
+      "Deleting _gap.xml\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'_gap.xml'"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "train_configs = ConfigSet([train_fname, isolated_at_fname])\n",
     "wfl.fit.gap.simple.run_gap_fit(\n",
@@ -478,9 +570,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Creating job gap-eval_chunk_0\n",
+      "ExPyRe gap-eval_chunk_0 constructor done stage in files 1678315173.070296\n",
+      "Starting job for gap-eval_chunk_0_LUnTADgt4YxX5N5SOMSZa4TQqVrf4uSXxIX5cKGHcdo=_h_b7d327\n",
+      "Gathering results for gap-eval_chunk_0_LUnTADgt4YxX5N5SOMSZa4TQqVrf4uSXxIX5cKGHcdo=_h_b7d327 remote 207347\n",
+      "Waiting for job gap-eval_chunk_0_LUnTADgt4YxX5N5SOMSZa4TQqVrf4uSXxIX5cKGHcdo=_h_b7d327 up to 3600 s: \n",
+      "qr\n",
+      "Running wfl.calculators.generic._run_autopara_wrappable with num_python_subprocesses=2, num_inputs_per_python_subprocess=10\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<wfl.configset.ConfigSet at 0x7f09ec5db400>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "train_fn_with_gap = \"7.1.train.gap.xyz\"\n",
     "test_fn_with_gap = \"7.2.test.gap.xyz\"\n",
@@ -503,6 +619,19 @@
     "    check_interval = 10, \n",
     "    input_files = [\"gap.xml*\"])\n",
     "\n",
+    "resources = Resources(\n",
+    "    max_time = \"15m\",\n",
+    "    num_cores = 2,\n",
+    "    partitions = \"any$\")\n",
+    "\n",
+    "remote_info = RemoteInfo(\n",
+    "    sys_name = \"local\",\n",
+    "    job_name = \"gap-eval\",\n",
+    "    resources = resources,\n",
+    "    check_interval = 10, \n",
+    "    partial_node=True,\n",
+    "    input_files = [\"gap.xml*\"],\n",
+    "    pre_cmds=[\"conda activate dev\"])\n",
     "\n",
     "gap_calc_autopara_info = AutoparaInfo(\n",
     "    remote_info=remote_info)\n",
@@ -529,9 +658,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      atomization_energy/a atomization_energy/a    F/c    F/c\n",
+      "                    meV/at                    #  meV/Å      #\n",
+      "test                 14.02                   50 559.73   5223\n",
+      "train                13.45                   50 558.58   5211\n",
+      "_ALL_                13.74                  100 559.16  10434\n"
+     ]
+    }
+   ],
    "source": [
     "# calculate atomization energies\n",
     "for fn in [train_fn_with_gap, test_fn_with_gap]:\n",
@@ -566,11 +707,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "nbsphinx": "hidden"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "isolated_atoms.xtb.xyz\n",
+      "1.ch.rdkit.xyz\n",
+      "2.ch.rdkit.md.traj.xyz\n",
+      "3.ch.rdkit.md.traj.filtered.xyz\n",
+      "4.ch.rdkit.md.traj.local_soap.xyz\n",
+      "5.ch.rdkit.md.traj.soap.cur_selection.xyz\n",
+      "6.1.train.xyz\n",
+      "6.2.test.xyz\n",
+      "gap.xml\n",
+      "7.1.train.gap.xyz\n",
+      "7.2.test.gap.xyz\n",
+      "gap_rmses.png\n",
+      "{'atomization_energy/atom': {'train': {'RMSE': 0.01345485566238174, 'MAE': 0.010637428620219111, 'count': 50}, '_ALL_': {'RMSE': 0.01374062897596706, 'MAE': 0.010792872309519384, 'count': 100}, 'test': {'RMSE': 0.014020578747499877, 'MAE': 0.010948315998819656, 'count': 50}}, 'forces/comp': {'train': {'RMSE': 0.5585758913153216, 'MAE': 0.41323806712531186, 'count': 5211}, '_ALL_': {'RMSE': 0.5591550158316371, 'MAE': 0.4112361438604562, 'count': 10434}, 'test': {'RMSE': 0.5597322126669515, 'MAE': 0.40923882007466966, 'count': 5223}}}\n"
+     ]
+    },
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;32m/home/eg475/dev/workflow/docs/source/examples.daisy_chain_mlip_fitting.ipynb Cell 28\u001b[0m in \u001b[0;36m<cell line: 45>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     <a href='vscode-notebook-cell://ssh-remote%2Bwo/home/eg475/dev/workflow/docs/source/examples.daisy_chain_mlip_fitting.ipynb#X36sdnNjb2RlLXJlbW90ZQ%3D%3D?line=42'>43</a>\u001b[0m             pred_val \u001b[39m=\u001b[39m errors[prop_key][config_key][measure_key]\n\u001b[1;32m     <a href='vscode-notebook-cell://ssh-remote%2Bwo/home/eg475/dev/workflow/docs/source/examples.daisy_chain_mlip_fitting.ipynb#X36sdnNjb2RlLXJlbW90ZQ%3D%3D?line=43'>44</a>\u001b[0m             \u001b[39massert\u001b[39;00m val \u001b[39m==\u001b[39m approx(pred_val, \u001b[39mabs\u001b[39m\u001b[39m=\u001b[39m\u001b[39m3e-1\u001b[39m), \u001b[39mf\u001b[39m\u001b[39m'\u001b[39m\u001b[39mMismatch for ref prop \u001b[39m\u001b[39m{\u001b[39;00mprop_key\u001b[39m}\u001b[39;00m\u001b[39m config \u001b[39m\u001b[39m{\u001b[39;00mconfig_key\u001b[39m}\u001b[39;00m\u001b[39m measure \u001b[39m\u001b[39m{\u001b[39;00mmeasure_key\u001b[39m}\u001b[39;00m\u001b[39m ref \u001b[39m\u001b[39m{\u001b[39;00mval\u001b[39m}\u001b[39;00m\u001b[39m != actual \u001b[39m\u001b[39m{\u001b[39;00mpred_val\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\n\u001b[0;32m---> <a href='vscode-notebook-cell://ssh-remote%2Bwo/home/eg475/dev/workflow/docs/source/examples.daisy_chain_mlip_fitting.ipynb#X36sdnNjb2RlLXJlbW90ZQ%3D%3D?line=44'>45</a>\u001b[0m \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
    "source": [
     "from pathlib import Path\n",
     "from pytest import approx\n",
@@ -615,7 +787,8 @@
     "            if measure_key == \"count\":\n",
     "                continue\n",
     "            pred_val = errors[prop_key][config_key][measure_key]\n",
-    "            assert val == approx(pred_val, abs=3e-1), f'Mismatch for ref prop {prop_key} config {config_key} measure {measure_key} ref {val} != actual {pred_val}'\n"
+    "            assert val == approx(pred_val, abs=3e-1), f'Mismatch for ref prop {prop_key} config {config_key} measure {measure_key} ref {val} != actual {pred_val}'\n",
+    "assert False\n"
    ]
   },
   {

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -28,9 +28,8 @@ def _get_coding_blocks(nb_file):
 )
 def test_example(tmp_path, nb_file, idx_execute, monkeypatch, needs_expyre, expyre_systems):
     if needs_expyre and "github" not in expyre_systems:
-        print(f'Notebook {nb_file} requires ExPyRe, but system "github" is not in config.json or'
+        pytest.skip(reason=f'Notebook {nb_file} requires ExPyRe, but system "github" is not in config.json or'
               f'"EXPYRE_PYTEST_SYSTEMS" environment variable.')
-        return
     print("running test_example", nb_file)
     basepath = os.path.join(f'{os.path.dirname(__file__)}/../docs/source')
     coding_blocks = _get_coding_blocks(f'{basepath}/{nb_file}')

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -70,6 +70,22 @@ def test_NVT_const_T(cu_slab):
     assert all([at.info['MD_temperature_K'] == 500.0 for at in atoms_traj])
 
 
+def test_NVT_const_T_mult_configs_distinct_seeds(cu_slab):
+
+    calc = EMT()
+
+    inputs = ConfigSet([cu_slab.copy() for _ in range(4)])
+    outputs = OutputSpec()
+
+    atoms_traj = md.sample(inputs, outputs, calculator=calc, steps=300, dt=1.0,
+                           temperature = 500.0, temperature_tau=30.0, autopara_rng_seed=23875)
+
+    last_configs = [list(group)[-1] for group in atoms_traj.groups()]
+    last_vs = [np.linalg.norm(at.get_velocities()) for at in last_configs]
+    print("BOB last_vs", last_vs)
+    assert all([v != last_vs[0] for v in last_vs[1:]])
+
+
 def test_NVT_simple_ramp(cu_slab):
 
     calc = EMT()

--- a/tests/test_remote_run.py
+++ b/tests/test_remote_run.py
@@ -171,7 +171,7 @@ def do_generic_calc(tmp_path, sys_name, monkeypatch, remoteinfo_env):
     assert max(dev) < 1.0e-8
 
     # maybe can do the test without being so sensitive to timing?
-    assert dt_rerun < 20
+    assert dt_rerun < dt / 4.0
 
 
 def do_minim(tmp_path, sys_name, monkeypatch, remoteinfo_env):

--- a/tests/test_remote_run.py
+++ b/tests/test_remote_run.py
@@ -161,7 +161,8 @@ def do_generic_calc(tmp_path, sys_name, monkeypatch, remoteinfo_env):
     co = OutputSpec(tmp_path / f'ats_o_{sys_name}.xyz')
 
     t0 = time.time()
-    results = generic.run(inputs=ci, outputs=co, calculator=calc, properties=["energy", "forces"])
+    results = generic.run(inputs=ci, outputs=co, calculator=calc, properties=["energy", "forces"],
+                          autopara_info={"remote_info": ri})
     dt_rerun = time.time() - t0
     print('remote parallel calc_time', dt_rerun)
 

--- a/tests/test_remote_run.py
+++ b/tests/test_remote_run.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.remote
 
 from wfl.configset import ConfigSet, OutputSpec
 from wfl.calculators import generic
-from wfl.generate import optimize
+from wfl.generate import optimize, md
 from wfl.calculators import generic
 from wfl.calculators.vasp import Vasp
 from wfl.autoparallelize.autoparainfo import AutoparaInfo
@@ -33,13 +33,20 @@ def test_generic_calc(tmp_path, expyre_systems, monkeypatch, remoteinfo_env):
         do_generic_calc(tmp_path, sys_name, monkeypatch, remoteinfo_env)
 
 
-# do we need this tested remotely as well?
-def test_minim_local(tmp_path, expyre_systems, monkeypatch, remoteinfo_env):
+def test_minim(tmp_path, expyre_systems, monkeypatch, remoteinfo_env):
     for sys_name in expyre_systems:
         if sys_name.startswith('_'):
             continue
 
         do_minim(tmp_path, sys_name, monkeypatch, remoteinfo_env)
+
+
+def test_md_deterministic(tmp_path, expyre_systems, monkeypatch, remoteinfo_env):
+    for sys_name in expyre_systems:
+        if sys_name.startswith('_'):
+            continue
+
+        do_md_deterministic(tmp_path, sys_name, monkeypatch, remoteinfo_env)
 
 
 def test_vasp_fail(tmp_path, expyre_systems, monkeypatch, remoteinfo_env):
@@ -59,9 +66,7 @@ def do_vasp_fail(tmp_path, sys_name, monkeypatch, remoteinfo_env):
 
     remoteinfo_env(ri)
 
-    ri = {'test_remote_run.py::do_vasp_fail,calculators/generic.py::run': ri}
     print('RemoteInfo', ri)
-    monkeypatch.setenv('WFL_EXPYRE_INFO', json.dumps(ri))
 
     nconfigs = 2
     nat = 8
@@ -87,7 +92,8 @@ def do_vasp_fail(tmp_path, sys_name, monkeypatch, remoteinfo_env):
     # jobs should fail because of bad executable
     results = generic.run(inputs=ci, outputs=co,
                           calculator=Vasp(encut= 200, pp='POTCARs'),
-                          output_prefix='TEST_')
+                          output_prefix='TEST_',
+                          autopara_info={"remote_info": ri})
 
     for at in ase.io.read(tmp_path / f'ats_o_{sys_name}.xyz', ':'):
         ## ase.io.write(sys.stdout, at, format='extxyz')
@@ -104,9 +110,7 @@ def do_generic_calc(tmp_path, sys_name, monkeypatch, remoteinfo_env):
 
     remoteinfo_env(ri)
 
-    ri = {'test_remote_run.py::do_generic_calc,calculators/generic.py::run': ri}
     print('RemoteInfo', ri)
-    monkeypatch.setenv('WFL_EXPYRE_INFO', json.dumps(ri))
 
     nconfigs = 1000
     nat = 40
@@ -140,7 +144,8 @@ def do_generic_calc(tmp_path, sys_name, monkeypatch, remoteinfo_env):
     monkeypatch.setenv('WFL_EXPYRE_NO_MARK_PROCESSED', '1')
 
     t0 = time.time()
-    results = generic.run(inputs=ci, outputs=co, calculator=calc, properties=["energy", "forces"])
+    results = generic.run(inputs=ci, outputs=co, calculator=calc, properties=["energy", "forces"],
+                          autopara_info={"remote_info": ri})
     dt = time.time() - t0
     print('remote parallel calc_time', dt)
 
@@ -175,7 +180,6 @@ def do_minim(tmp_path, sys_name, monkeypatch, remoteinfo_env):
 
     remoteinfo_env(ri)
 
-    ri = {'test_remote_run.py::do_minim,generate_configs/minim.py::run': ri}
     print('RemoteInfo', ri)
 
     nconfigs = 100
@@ -203,12 +207,9 @@ def do_minim(tmp_path, sys_name, monkeypatch, remoteinfo_env):
     co = OutputSpec([f.replace('_i_', '_o_local_') for f in infiles])
     results = optimize.run(inputs=ci, outputs=co, calculator=(EMT, [], {}), steps=5)
 
-    # run remotely
-    monkeypatch.setenv('WFL_EXPYRE_INFO', json.dumps(ri))
-
     co = OutputSpec([f.replace('_i_', '_o_') for f in infiles])
     t0 = time.time()
-    results = optimize.run(inputs=ci, outputs=co, calculator=(EMT, [], {}), steps=5)
+    results = optimize.run(inputs=ci, outputs=co, calculator=(EMT, [], {}), steps=5, autopara_info={"remote_info": ri})
     dt = time.time() - t0
     print('remote parallel calc_time', dt)
 
@@ -340,3 +341,50 @@ def do_resubmit_killed_jobs(tmp_path, sys_name, monkeypatch, remoteinfo_env):
     # make sure all have results
     assert len(list(results)) == len(ats)
     assert all(["EMT_energy" in at.info for at in results])
+
+
+def do_md_deterministic(tmp_path, sys_name, monkeypatch, remoteinfo_env):
+    ri = {'sys_name': sys_name, 'job_name': 'pytest_'+sys_name,
+          'resources': {'max_time': '1h', 'num_nodes': 1},
+          'num_inputs_per_queued_job': -36, 'check_interval': 10}
+
+    remoteinfo_env(ri)
+
+    print('RemoteInfo', ri)
+
+    nconfigs = 40
+    nat = 40
+    a0 = (nat * 20.0) ** (1.0/3.0)
+
+    sys.stderr.write('Creating atoms\n')
+
+    np.random.seed(5)
+    ats_1 = [Atoms(f'Al{nat}', cell=[a0]*3, scaled_positions=np.random.uniform(size=((nat, 3))), pbc=[True] * 3) for _ in range(nconfigs // 2)]
+    for at_i, at in enumerate(ats_1):
+        at.info['orig_file'] = '1'
+        at.info['orig_file_seq_no'] = at_i
+    ats_2 = [Atoms(f'Al{nat}', cell=[a0]*3, scaled_positions=np.random.uniform(size=((nat, 3))), pbc=[True] * 3) for _ in range(nconfigs // 2)]
+    for at_i, at in enumerate(ats_2):
+        at.info['orig_file'] = '2'
+        at.info['orig_file_seq_no'] = at_i
+    ase.io.write(tmp_path / f'ats_i_{sys_name}_1.xyz', ats_1)
+    ase.io.write(tmp_path / f'ats_i_{sys_name}_2.xyz', ats_2)
+
+    infiles = [str(tmp_path / f'ats_i_{sys_name}_1.xyz'), str(tmp_path / f'ats_i_{sys_name}_2.xyz')]
+    ci = ConfigSet(infiles)
+
+    # run locally
+    co = OutputSpec([f.replace('_i_', '_o_local_') for f in infiles])
+    results_loc = md.sample(inputs=ci, outputs=co, calculator=(EMT, [], {}), steps=10, dt=0.2, temperature=100.0, temperature_tau=10.0,
+                            autopara_rng_seed=20)
+
+    co = OutputSpec([f.replace('_i_', '_o_') for f in infiles])
+    t0 = time.time()
+    results_remote = md.sample(inputs=ci, outputs=co, calculator=(EMT, [], {}), steps=10, dt=0.2, temperature=100.0, temperature_tau=10.0,
+                               autopara_rng_seed=20, autopara_info={"remote_info": ri})
+    dt = time.time() - t0
+    print('remote parallel calc_time', dt)
+
+    for at in zip(results_loc, results_remote):
+        print("BOB", [np.linalg.norm(loc.positions - remote.positions) < 1.0e-12 for (loc, remote) in zip(results_loc, results_remote)])
+        assert all([np.linalg.norm(loc.positions - remote.positions) < 1.0e-12 for (loc, remote) in zip(results_loc, results_remote)])

--- a/wfl/autoparallelize/base.py
+++ b/wfl/autoparallelize/base.py
@@ -120,11 +120,17 @@ def autoparallelize(func, *args, def_autopara_info={}, **kwargs):
             return autoparallelize(op, *args, def_autopara_info={"autoparallelize_keyword_param_1": val, "autoparallelize_keyword_param_2": val, ... }, **kwargs )
         autoparallelized_op.doc = autopara_docstring(op.__doc__, "iterable_contents")
 
-    The autoparallelized function can then be called with 
+    The autoparallelized function can then be called with
 
     .. code-block:: python
 
         parallelized_op(inputs, outputs, [args of op], autopara_info=AutoparaInfo(arg1=val1, ...), [kwargs of op])
+
+    If the op takes the argument `autopara_per_item_info` a list of dicts with info for each item will be
+    passed, currently including `rng_seed` and `item_i`.
+
+    If op takes the argument `autopara_rng_seed` it will be used as a global seed to generate the per-item seeds
+    from.
 
 
     Parameters
@@ -145,7 +151,6 @@ def autoparallelize(func, *args, def_autopara_info={}, **kwargs):
     -------
     wrapped_func_out: results of calling the function wrapped in autoparallelize via _autoparallelize_ll
     """
-
     # copy kwargs and args so they can be modified for call to autoparallelize
     kwargs = kwargs.copy()
     args = list(args)
@@ -238,10 +243,10 @@ def _autoparallelize_ll(num_python_subprocesses, num_inputs_per_python_subproces
             return outputspec.to_ConfigSet()
 
     if remote_info is not None:
-        out = do_remotely(remote_info, hash_ignore, num_inputs_per_python_subprocess, iterable, outputspec,
-                          op, iterable_arg, skip_failed, initializer, args, kwargs)
+        out = do_remotely(remote_info, hash_ignore, num_inputs_per_python_subprocess, iterable, outputspec, op, iterable_arg,
+                          skip_failed=skip_failed, initializer=initializer, args=args, kwargs=kwargs)
     else:
         out = do_in_pool(num_python_subprocesses, num_inputs_per_python_subprocess, iterable, outputspec, op, iterable_arg,
-                         skip_failed, initializer, args, kwargs)
+                         skip_failed=skip_failed, initializer=initializer, args=args, kwargs=kwargs)
 
     return out

--- a/wfl/autoparallelize/pool.py
+++ b/wfl/autoparallelize/pool.py
@@ -6,13 +6,15 @@ import inspect
 import functools
 from multiprocessing.pool import Pool
 
+from ase.atoms import Atoms
+
 from wfl.configset import ConfigSet
 from wfl.autoparallelize.mpipool_support import wfl_mpipool
 
-from .utils import grouper
+from .utils import grouper, get_root_global_seed, set_autopara_per_item_info
 
 
-def _wrapped_autopara_wrappable(op, iterable_arg, args, kwargs, item_inputs):
+def _wrapped_autopara_wrappable(op, iterable_arg, root_global_seed, prev_per_item_info, args, kwargs, item_inputs):
     """Wrap an operation to be run in parallel by autoparallelize
 
     Parameters:
@@ -22,13 +24,18 @@ def _wrapped_autopara_wrappable(op, iterable_arg, args, kwargs, item_inputs):
         iterable_arg: int/str
             where to put iterable item argument. If int, place in positional args,
                 or if str, key in kwargs
+        root_global_seed: int
+            root of seed used to generate per-item local seeds
+        prev_per_item_info: list(dict)
+            list of per-item info
         args: list
             list of positional args
         kwargs: dict
             dict of keyword args
         item_inputs: iterable(2-tuples)
-            One or more 2-tuples. First field of each is quantities to be passed to function in
-                iterable_arg, and second field is a quantity to be passed back with the output.
+            One or more 2-tuples. First field of each is a 2-tuple (item_i, item), where item is 
+                to be passed to function in iterable_arg and item_i is its number in the
+                overall list, and second field is a quantity to be passed back with the output.
 
     Returns:
     -------
@@ -39,7 +46,10 @@ def _wrapped_autopara_wrappable(op, iterable_arg, args, kwargs, item_inputs):
         assert len(item) == 2
 
     # item_inputs is iterable of 2-tuples
-    item_list = [item_input[0] for item_input in item_inputs]
+    item_i_list = [item_input[0][0] for item_input in item_inputs]
+    item_list = [item_input[0][1] for item_input in item_inputs]
+
+    set_autopara_per_item_info(kwargs, op, root_global_seed, prev_per_item_info, item_i_list)
 
     if isinstance(iterable_arg, int):
         u_args = args[0:iterable_arg] + (item_list,) + args[iterable_arg:]
@@ -89,7 +99,7 @@ def do_in_pool(num_python_subprocesses=None, num_inputs_per_python_subprocess=1,
     -------
     ConfigSet containing returned configs if outputspec is not None, otherwise None
     """
-    assert len(initializer) == 2
+    assert len(initializer) == 2, f"Bad initializer {initializer}"
 
     if num_python_subprocesses is None:
         num_python_subprocesses = int(os.environ.get('WFL_NUM_PYTHON_SUBPROCESSES', 0))
@@ -98,9 +108,16 @@ def do_in_pool(num_python_subprocesses=None, num_inputs_per_python_subprocess=1,
     did_no_work = True
 
     if isinstance(iterable, ConfigSet):
-        items_inputs_generator = grouper(num_inputs_per_python_subprocess, ((item, item.info.get("_ConfigSet_loc")) for item in iterable))
+        items_inputs_generator = grouper(num_inputs_per_python_subprocess,
+                                         ((item, item[1].info.get("_ConfigSet_loc")) for item in enumerate(iterable)))
     else:
-        items_inputs_generator = grouper(num_inputs_per_python_subprocess, ((item, None) for item in iterable))
+        items_inputs_generator = grouper(num_inputs_per_python_subprocess,
+                                         ((item, None) for item in enumerate(iterable)))
+
+    # for local seeds if requested
+    root_global_seed = get_root_global_seed(kwargs, op, f"{op}")
+    # other per-item info
+    prev_per_item_info = kwargs.get("autopara_per_item_info")
 
     if num_python_subprocesses > 0:
         # use multiprocessing
@@ -113,7 +130,7 @@ def do_in_pool(num_python_subprocesses=None, num_inputs_per_python_subprocess=1,
                           f'always uses all MPI processes {wfl_mpipool.size}')
             if initializer[0] is not None:
                 # generate a task for each mpi process that will call initializer with positional initargs
-                _ = wfl_mpipool.map(functools.partial(_wrapped_autopara_wrappable, initializer[0], None, initializer[1], {}),
+                _ = wfl_mpipool.map(functools.partial(_wrapped_autopara_wrappable, initializer[0], None, None, None, initializer[1], {}),
                                     grouper(1, ((None, None) for i in range(wfl_mpipool.size))))
             pool = wfl_mpipool
         else:
@@ -127,7 +144,7 @@ def do_in_pool(num_python_subprocesses=None, num_inputs_per_python_subprocess=1,
             map_f = pool.map
         else:
             map_f = pool.imap
-        results = map_f(functools.partial(_wrapped_autopara_wrappable, op, iterable_arg, args, kwargs), items_inputs_generator)
+        results = map_f(functools.partial(_wrapped_autopara_wrappable, op, iterable_arg, root_global_seed, prev_per_item_info, args, kwargs), items_inputs_generator)
 
         if not wfl_mpipool:
             # only close pool if it's from multiprocessing.pool
@@ -153,7 +170,7 @@ def do_in_pool(num_python_subprocesses=None, num_inputs_per_python_subprocess=1,
         # can change configs in-place, which is different from Pool.map().  Should we pickle and 
         # unpickle to better reproduce the behavior of Pool.map() ?
         for items_inputs_group in items_inputs_generator:
-            result_group = _wrapped_autopara_wrappable(op, iterable_arg, args, kwargs, items_inputs_group)
+            result_group = _wrapped_autopara_wrappable(op, iterable_arg, root_global_seed, prev_per_item_info, args, kwargs, items_inputs_group)
 
             if outputspec is not None:
                 for at, from_input_loc in result_group:

--- a/wfl/generate/md/__init__.py
+++ b/wfl/generate/md/__init__.py
@@ -21,7 +21,8 @@ bar = 1.0e-4 * GPa
 def _sample_autopara_wrappable(atoms, calculator, steps, dt, temperature=None, temperature_tau=None,
               pressure=None, pressure_tau=None, compressibility_fd_displ=0.01,
               traj_step_interval=1, skip_failures=True, results_prefix='md_', verbose=False, update_config_type=True,
-              traj_select_during_func=lambda at: True, traj_select_after_func=None, abort_check=None):
+              traj_select_during_func=lambda at: True, traj_select_after_func=None, abort_check=None,
+              autopara_rng_seed=None, autopara_per_item_info=None):
     """runs an MD trajectory with aggresive, not necessarily physical, integrators for
     sampling configs
 
@@ -69,6 +70,9 @@ def _sample_autopara_wrappable(atoms, calculator, steps, dt, temperature=None, t
     abort_check: default None,
         wfl.generate.md.abort_base.AbortBase - derived class that
         checks the MD snapshots and aborts the simulation on some condition.
+    autopara_rng_seed: int, default None
+        global seed used to initialize rng so that each operation uses a different but
+        deterministic local seed, use a random value if None
 
     Returns
     -------
@@ -108,7 +112,10 @@ def _sample_autopara_wrappable(atoms, calculator, steps, dt, temperature=None, t
                 if 'n_stages' not in t_stage:
                     t_stage['n_stages'] = 10
 
-    for at in atoms_to_list(atoms):
+    for at_i, at in enumerate(atoms_to_list(atoms)):
+        if autopara_per_item_info is not None:
+            np.random.seed(autopara_per_item_info[at_i]["rng_seed"])
+
         at.calc = calculator
         compressibility = None
         if pressure is not None:
@@ -240,15 +247,8 @@ def _sample_autopara_wrappable(atoms, calculator, steps, dt, temperature=None, t
 
 
 def sample(*args, **kwargs):
-    # Normally each thread needs to call np.random.seed so that it will generate a different
-    # set of random numbers.  This env var overrides that to produce deterministic output,
-    # for purposes like testing
-    if 'WFL_DETERMINISTIC_HACK' in os.environ:
-        initializer = (None, [])
-    else:
-        initializer = (np.random.seed, [])
-    def_autopara_info={"initializer":initializer, "hash_ignore":["initializer"]}
+    def_autopara_info = {"num_inputs_per_python_subprocess": 10}
 
     return autoparallelize(_sample_autopara_wrappable, *args,
-        def_autopara_info=def_autopara_info, **kwargs)
+                           def_autopara_info=def_autopara_info, **kwargs)
 autoparallelize_docstring(sample, _sample_autopara_wrappable, "Atoms")


### PR DESCRIPTION
Used to set per-item info, including number of config in overall sequence, as well as unique local rng seed, chosen well (hopefully) for parallel operation (see https://numpy.org/doc/stable/reference/random/parallel.html#sequence-of-integer-seeds).

Makes it possible to run deterministic  stochastic autopara ops (like md, for velocities, optimize, for random pressure, and minimahopping).

