### PR TITLE
pass AutoparaInfo settings to remote jobs

### DIFF
--- a/tests/test_remote_run.py
+++ b/tests/test_remote_run.py
@@ -387,5 +387,5 @@ def do_md_deterministic(tmp_path, sys_name, monkeypatch, remoteinfo_env):
     print('remote parallel calc_time', dt)
 
     for at in zip(results_loc, results_remote):
-        print("BOB", [np.linalg.norm(loc.positions - remote.positions) < 1.0e-12 for (loc, remote) in zip(results_loc, results_remote)])
+        # print("BOB", [np.linalg.norm(loc.positions - remote.positions) < 1.0e-12 for (loc, remote) in zip(results_loc, results_remote)])
         assert all([np.linalg.norm(loc.positions - remote.positions) < 1.0e-12 for (loc, remote) in zip(results_loc, results_remote)])

--- a/wfl/autoparallelize/autoparainfo.py
+++ b/wfl/autoparallelize/autoparainfo.py
@@ -18,9 +18,6 @@ class AutoparaInfo:
     initializer: (func, func_kwargs), default (None, [])
         initializer to be called when each python subprocess is started
 
-    hash_ignore: list(str), default []
-        list of arguments to ignore when doing hash of remote function arguments to determine if it's already been done
-
     num_python_subprocesses: int, default None
         number of python subprocesses
 
@@ -35,7 +32,6 @@ class AutoparaInfo:
                "iterable_arg": 0,
                "skip_failed": True,
                "initializer": (None, []),
-               "hash_ignore": [],
                "num_python_subprocesses": None,
                "remote_info": None,
                "remote_label": None}

--- a/wfl/autoparallelize/remote.py
+++ b/wfl/autoparallelize/remote.py
@@ -12,16 +12,15 @@ from .pool import do_in_pool
 from expyre import ExPyRe, ExPyReJobDiedError
 
 
-def do_remotely(remote_info, hash_ignore=[], num_inputs_per_python_subprocess=1, iterable=None, outputspec=None,
-                op=None, iterable_arg=0, skip_failed=True, initializer=(None, []),
-                args=[], kwargs={}, quiet=False):
+def do_remotely(autopara_info, iterable=None, outputspec=None, op=None, args=[], kwargs={}, quiet=False):
     """run tasks as series of remote jobs
 
     Parameters
     ----------
-    remote_info: RemoteInfo
-        object with all information on remote job, including system, resources, job num_inputs_per_python_subprocess,
-        etc, or dict of kwargs for its constructor
+    autopara_info: AutoparaInfo
+        object with all information on autoparallelizing remote job, including autopara_info.remote_info 
+        which contains RemoteInfo with information on remote job, including system, resources, job 
+        num_inputs_per_python_subprocess, etc, or dict of kwargs for its constructor
     quiet: bool, default False
         do not output (to stderr) progress info
 
@@ -30,8 +29,18 @@ def do_remotely(remote_info, hash_ignore=[], num_inputs_per_python_subprocess=1,
     if ExPyRe is None:
         raise RuntimeError('Cannot run as remote jobs since expyre module could not be imported')
 
+    remote_info = autopara_info.remote_info
+    autopara_info.remote_info = None
+
+    if autopara_info.num_python_subprocesses is None:
+        # number of python processes for autoparallelized remote job not specfied explicitly
+        if all([not var.startswith("WFL_NUM_PYTHON_SUBPROCESSES=") for var in remote_info.env_vars]):
+            # user didn't explicitly set WFL_NUM_PYTHON_SUBPROCESSES for remote job
+            # so set its default equal to number of cores per node
+            remote_info.env_vars += ["WFL_NUM_PYTHON_SUBPROCESSES=${EXPYRE_NUM_CORES_PER_NODE}"]
+
     if remote_info.num_inputs_per_queued_job < 0:
-        remote_info.num_inputs_per_queued_job = -remote_info.num_inputs_per_queued_job * num_inputs_per_python_subprocess
+        remote_info.num_inputs_per_queued_job = -remote_info.num_inputs_per_queued_job * autopara_info.num_inputs_per_python_subprocess
 
     if isinstance(iterable, ConfigSet):
         items_inputs_generator = grouper(remote_info.num_inputs_per_queued_job,
@@ -78,16 +87,22 @@ def do_remotely(remote_info, hash_ignore=[], num_inputs_per_python_subprocess=1,
         else:
             job_iterable = items
         co = OutputSpec()
-        # remote job will have to set num_python_subprocesses appropriately for its node
+
+        # NOTE: would it be cleaner if remote function was autoparallelize() instead of do_in_pool()
+        #
         # ignore configset out for hashing of inputs, since that doesn't affect function
-        # calls that have to happen (also it's not repeatable for some reason)
+        #     calls that have to happen (also it's not repeatable for some reason)
         xprs.append(ExPyRe(name=job_name, pre_run_commands=remote_info.pre_cmds, post_run_commands=remote_info.post_cmds,
-                            hash_ignore=hash_ignore + ['outputspec'],
+                            hash_ignore=remote_info.hash_ignore + ['outputspec'],
                             env_vars=remote_info.env_vars, input_files=remote_info.input_files,
                             output_files=remote_info.output_files, function=do_in_pool,
-                            kwargs={'num_python_subprocesses': None, 'num_inputs_per_python_subprocess': num_inputs_per_python_subprocess, 'iterable': job_iterable,
-                                    'outputspec': co, 'op': op, 'iterable_arg': iterable_arg,
-                                    'skip_failed': skip_failed, 'initializer': initializer, 'args': args, 'kwargs': kwargs}))
+                            kwargs={'num_python_subprocesses': autopara_info.num_python_subprocesses,
+                                    'num_inputs_per_python_subprocess': autopara_info.num_inputs_per_python_subprocess,
+                                    'iterable': job_iterable, 'outputspec': co, 'op': op,
+                                    'iterable_arg': autopara_info.iterable_arg,
+                                    'skip_failed': autopara_info.skip_failed,
+                                    'initializer': autopara_info.initializer,
+                                    'args': args, 'kwargs': kwargs}))
 
     # start jobs (shouldn't do anything if they've already been started)
     for xpr in xprs:

--- a/wfl/autoparallelize/remoteinfo.py
+++ b/wfl/autoparallelize/remoteinfo.py
@@ -39,11 +39,13 @@ class RemoteInfo:
     resubmit_killed_jobs: bool, default False
         resubmit jobs that were killed without an exit status (out of walltime or crashed), 
         hoping that other parameters such as walltime or memory have been changed to make run complete this time
+    hash_ignore: list(str), default []
+        list of arguments to ignore when doing hash of remote function arguments to determine if it's already been done
     """
     def __init__(self, sys_name, job_name, resources, num_inputs_per_queued_job=-100, pre_cmds=[], post_cmds=[],
                  env_vars=[], input_files=[], output_files=[], header_extra=[],
                  exact_fit=True, partial_node=False, timeout=3600, check_interval=30,
-                 ignore_failed_jobs=False, resubmit_killed_jobs=False):
+                 ignore_failed_jobs=False, resubmit_killed_jobs=False, hash_ignore=[]):
 
         self.sys_name = sys_name
         self.job_name = job_name
@@ -51,12 +53,7 @@ class RemoteInfo:
         self.num_inputs_per_queued_job = num_inputs_per_queued_job
         self.pre_cmds = pre_cmds.copy()
         self.post_cmds = post_cmds.copy()
-        self.env_vars = []
-        if all([not var.startswith("WFL_NUM_PYTHON_SUBPROCESSES=") for var in env_vars]):
-            # user didn't explicitly set WFL_NUM_PYTHON_SUBPROCESSES, so set it to default
-            # equal to number of cores per node
-            self.env_vars += ["WFL_NUM_PYTHON_SUBPROCESSES=${EXPYRE_NUM_CORES_PER_NODE}"]
-        self.env_vars += env_vars
+        self.env_vars = env_vars.copy()
         self.input_files = input_files.copy()
         self.output_files = output_files.copy()
         self.header_extra = header_extra.copy()
@@ -67,6 +64,7 @@ class RemoteInfo:
         self.check_interval = check_interval
         self.ignore_failed_jobs = ignore_failed_jobs
         self.resubmit_killed_jobs = resubmit_killed_jobs
+        self.hash_ignore = hash_ignore.copy()
 
 
     def __str__(self):

--- a/wfl/autoparallelize/utils.py
+++ b/wfl/autoparallelize/utils.py
@@ -46,6 +46,8 @@ def get_remote_info(remote_info, remote_label, env_var="WFL_EXPYRE_INFO"):
         RemoteInfo kwrgs with keys that match end of stack trace with function names separated by '.'.
     remote_label: str, default None
         remote_label to use for operation, to match to remote_info dict keys.  If none, use calling routine filename '::' calling function
+    env_var: str, default "WFL_EXPYRE_INFO"
+        environment var to get information from if not present in `remote\_info` argument
 
     Returns
     -------


### PR DESCRIPTION
Refactor `RemoteInfo` and `AutoparaInfo` related code so that all `AutoparaInfo` settings are applied to remote job, in particular `num_python_subprocesses`

Closes #216
