### PR TITLE
Vasp calculator update

### DIFF
--- a/wfl/calculators/utils.py
+++ b/wfl/calculators/utils.py
@@ -112,6 +112,8 @@ def save_results(atoms, properties, results_prefix=None):
         atoms_results['magmoms'] = atoms.get_magnetic_moments()
     if 'energies' in properties:
         atoms_results['energies'] = atoms.get_potential_energies()
+    if 'converged' in properties and results_prefix =! None:
+        config_results['converged'] = atoms.get_calculator().read_convergence()
 
     if "extra_results" in dir(atoms.calc):
         if results_prefix is None and (len(atoms.calc.extra_results.get("config", {})) > 0 or

--- a/wfl/calculators/utils.py
+++ b/wfl/calculators/utils.py
@@ -112,7 +112,7 @@ def save_results(atoms, properties, results_prefix=None):
         atoms_results['magmoms'] = atoms.get_magnetic_moments()
     if 'energies' in properties:
         atoms_results['energies'] = atoms.get_potential_energies()
-    if 'converged' in properties and results_prefix =! None:
+    if 'converged' in properties and results_prefix != None:
         config_results['converged'] = atoms.get_calculator().read_convergence()
 
     if "extra_results" in dir(atoms.calc):

--- a/wfl/calculators/vasp.py
+++ b/wfl/calculators/vasp.py
@@ -70,7 +70,7 @@ class Vasp(WFLFileIOCalculator, ASE_Vasp):
                  workdir=None, scratchdir=None,
                  calculator_exec=None, calculator_exec_gamma=None,
                  **kwargs):
-
+        
         # get initialparams from env var
         kwargs_use = {}
         if 'WFL_VASP_KWARGS' in os.environ:
@@ -136,7 +136,10 @@ class Vasp(WFLFileIOCalculator, ASE_Vasp):
         if nonperiodic:
             self.float_params["kspacing"] = 100000.0
             self.bool_params["kgamma"] = True
-
+        
+        if 'kpts' in self.atoms.info.keys():
+            print(self.atoms.info['kpts'])
+            self.input_params['kpts'] = self.atoms.info['kpts']
 
     def per_config_restore(self, atoms):
         # undo pbc change
@@ -209,3 +212,4 @@ class Vasp(WFLFileIOCalculator, ASE_Vasp):
 
             # undo communicator mangling
             world.comm = orig_world_comm
+


### PR DESCRIPTION
- Enabled per configuration kpoint setting (important for slabs, because VASPs kspacing does not work)
- Added _converged_ as retrievable propertie (If VASP reaches the maximum number of electronics steps, it returns the energies and forces even if not converged, and without any error.)