### PR TITLE
Update MACE fit to work with expyre jobs 

### DIFF
--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -178,7 +178,7 @@ jobs:
           # stop the build if there are Python syntax errors or undefined names
           flake8 wfl/ --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings.
-          flake8 wfl/ --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
+          flake8 wfl/ --count --exit-zero --max-complexity=20 --max-line-length=140 --ignore=E127,E128 --statistics
 
       - name: Test with pytest - plain
         if: env.coverage-on-version != matrix.python-version

--- a/complete_pytest.tin
+++ b/complete_pytest.tin
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module purge
-module load compiler/gnu python/system python_extras/quippy
+module load compiler/gnu python/system python_extras/quippy lapack/mkl
 
 # should include both tin and tin_ssh - not as good as real remote machine, but maybe close enough
 if [ -z $EXPYRE_PYTEST_SYSTEMS ]; then
@@ -21,6 +21,10 @@ export PYTEST_VASP_POTCAR_DIR=$VASP_PATH/pot/rev_54/PBE
 # QE
 module load dft/pwscf
 # no ORCA
+
+# cpu-only torch
+export PYTHONPATH=${HOME}/pytorch_cpu/lib64/python3.9/site-packages:${PYTHONPATH}
+export LD_PRELOAD=${MKLROOT}/lib/intel64/libmkl_core.so:${MKLROOT}/lib/intel64/libmkl_sequential.so:${MKLROOT}/lib/intel64/libmkl_gf_lp64.so
 
 export OPENBLAS_NUM_THREADS=1
 export MKL_NUM_THREADS=1

--- a/tests/test_ace_fitting.py
+++ b/tests/test_ace_fitting.py
@@ -13,7 +13,7 @@ from wfl.fit.ace import fit, prepare_params, prepare_configs
 try:
     ace_fit_jl_path()
 except:
-    pytestmark = pytest.mark.skip
+    pytestmark = pytest.mark.skip(reason="ace_fit_jl_path failed to find ace fitting script")
 
 def test_ace_fit_dry_run(request, tmp_path, monkeypatch, run_dir='run_dir'):
     print('getting fitting data from ', request.fspath)

--- a/wfl/autoparallelize/__init__.py
+++ b/wfl/autoparallelize/__init__.py
@@ -4,3 +4,5 @@ assert autoparallelize_docstring
 
 from .autoparainfo import AutoparaInfo
 from .remoteinfo import RemoteInfo
+
+__all__ = ["autoparallelize", "autoparallelize_docstring", "AutoparaInfo", "RemoteInfo"]

--- a/wfl/autoparallelize/autoparainfo.py
+++ b/wfl/autoparallelize/autoparainfo.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 class AutoparaInfo:
     """Object containing information required to autoparallelize a function
 

--- a/wfl/autoparallelize/base.py
+++ b/wfl/autoparallelize/base.py
@@ -1,12 +1,9 @@
 import sys
-import os
-import warnings
-import re
 import docstring_parser
 import inspect
 
 
-from wfl.configset import ConfigSet, OutputSpec
+from wfl.configset import OutputSpec
 from .pool import do_in_pool
 from .remote import do_remotely
 from .autoparainfo import AutoparaInfo
@@ -101,7 +98,7 @@ def autoparallelize_docstring(wrapped_func, wrappable_func, input_iterable_type,
             returns_i = p_i
     if returns_i is not None:
         # replace returns
-        parsed.meta[returns_i] =  docstring_parser.DocstringReturns(*_autopara_docstring_returns)
+        parsed.meta[returns_i] = docstring_parser.DocstringReturns(*_autopara_docstring_returns)
     else:
         # append returns
         parsed.meta.append(docstring_parser.DocstringReturns(*_autopara_docstring_returns))
@@ -117,7 +114,9 @@ def autoparallelize(func, *args, default_autopara_info={}, **kwargs):
     .. code-block:: python
 
         def autoparallelized_op(*args, **kwargs):
-            return autoparallelize(op, *args, default_autopara_info={"autoparallelize_keyword_param_1": val, "autoparallelize_keyword_param_2": val, ... }, **kwargs )
+            return autoparallelize(op, *args,
+                default_autopara_info={"autoparallelize_keyword_param_1": val, "autoparallelize_keyword_param_2": val, ... },
+                **kwargs )
         autoparallelized_op.doc = autopara_docstring(op.__doc__, "iterable_contents")
 
     The autoparallelized function can then be called with
@@ -139,7 +138,8 @@ def autoparallelize(func, *args, default_autopara_info={}, **kwargs):
         function to wrap in _autoparallelize_ll()
 
     *args: list
-        positional arguments to func, plus optional first or first and second inputs (iterable) and outputs (OutputSpec) arguments to wrapped function
+        positional arguments to func, plus optional first or first and second inputs (iterable) and outputs (OutputSpec) arguments
+        to wrapped function
 
     default_autopara_info: dict, default {}
         dict with default values for AutoparaInfo constructor keywords setting default autoparallelization info

--- a/wfl/autoparallelize/pool.py
+++ b/wfl/autoparallelize/pool.py
@@ -6,8 +6,6 @@ import inspect
 import functools
 from multiprocessing.pool import Pool
 
-from ase.atoms import Atoms
-
 from wfl.configset import ConfigSet
 from wfl.autoparallelize.mpipool_support import wfl_mpipool
 
@@ -33,7 +31,7 @@ def _wrapped_autopara_wrappable(op, iterable_arg, root_global_seed, prev_per_ite
         kwargs: dict
             dict of keyword args
         item_inputs: iterable(2-tuples)
-            One or more 2-tuples. First field of each is a 2-tuple (item_i, item), where item is 
+            One or more 2-tuples. First field of each is a 2-tuple (item_i, item), where item is
                 to be passed to function in iterable_arg and item_i is its number in the
                 overall list, and second field is a quantity to be passed back with the output.
 
@@ -71,7 +69,7 @@ def _wrapped_autopara_wrappable(op, iterable_arg, root_global_seed, prev_per_ite
 def do_in_pool(num_python_subprocesses=None, num_inputs_per_python_subprocess=1, iterable=None, outputspec=None, op=None, iterable_arg=0,
                skip_failed=True, initializer=(None, []), args=[], kwargs={}):
     """parallelize some operation over an iterable
-    
+
     Parameters
     ----------
     num_python_subprocesses: int, default os.environ['WFL_NUM_PYTHON_SUBPROCESSES']
@@ -144,7 +142,8 @@ def do_in_pool(num_python_subprocesses=None, num_inputs_per_python_subprocess=1,
             map_f = pool.map
         else:
             map_f = pool.imap
-        results = map_f(functools.partial(_wrapped_autopara_wrappable, op, iterable_arg, root_global_seed, prev_per_item_info, args, kwargs), items_inputs_generator)
+        results = map_f(functools.partial(_wrapped_autopara_wrappable, op, iterable_arg, root_global_seed,
+                                          prev_per_item_info, args, kwargs), items_inputs_generator)
 
         if not wfl_mpipool:
             # only close pool if it's from multiprocessing.pool
@@ -167,10 +166,11 @@ def do_in_pool(num_python_subprocesses=None, num_inputs_per_python_subprocess=1,
     else:
         # do directly: still not trivial because of num_inputs_per_python_subprocess
         # NOTE: this does not pickle configs to send to the remote processes, so called function
-        # can change configs in-place, which is different from Pool.map().  Should we pickle and 
+        # can change configs in-place, which is different from Pool.map().  Should we pickle and
         # unpickle to better reproduce the behavior of Pool.map() ?
         for items_inputs_group in items_inputs_generator:
-            result_group = _wrapped_autopara_wrappable(op, iterable_arg, root_global_seed, prev_per_item_info, args, kwargs, items_inputs_group)
+            result_group = _wrapped_autopara_wrappable(op, iterable_arg, root_global_seed, prev_per_item_info, args,
+                                                       kwargs, items_inputs_group)
 
             if outputspec is not None:
                 for at, from_input_loc in result_group:

--- a/wfl/autoparallelize/remote.py
+++ b/wfl/autoparallelize/remote.py
@@ -6,7 +6,6 @@ from ase.atoms import Atoms
 
 from wfl.configset import ConfigSet, OutputSpec
 from .utils import grouper, get_root_global_seed, set_autopara_per_item_info
-from .remoteinfo import RemoteInfo
 from .pool import do_in_pool
 
 from expyre import ExPyRe, ExPyReJobDiedError
@@ -18,8 +17,8 @@ def do_remotely(autopara_info, iterable=None, outputspec=None, op=None, args=[],
     Parameters
     ----------
     autopara_info: AutoparaInfo
-        object with all information on autoparallelizing remote job, including autopara_info.remote_info 
-        which contains RemoteInfo with information on remote job, including system, resources, job 
+        object with all information on autoparallelizing remote job, including autopara_info.remote_info
+        which contains RemoteInfo with information on remote job, including system, resources, job
         num_inputs_per_python_subprocess, etc, or dict of kwargs for its constructor
     quiet: bool, default False
         do not output (to stderr) progress info
@@ -136,10 +135,10 @@ def do_remotely(autopara_info, iterable=None, outputspec=None, op=None, args=[],
         stderr = None
         try:
             ats_out, stdout, stderr = xpr.get_results(timeout=remote_info.timeout, check_interval=remote_info.check_interval)
-        except Exception as exc:
-            print("stdout","-"*30)
+        except Exception:
+            print("stdout", "-" * 30)
             print(stdout)
-            print("stderr", "-"*30)
+            print("stderr", "-" * 30)
             print(stderr)
             warnings.warn(f'Failed in remote job {xpr.id} on {xpr.system_name}')
             if not remote_info.ignore_failed_jobs:

--- a/wfl/autoparallelize/remoteinfo.py
+++ b/wfl/autoparallelize/remoteinfo.py
@@ -13,7 +13,8 @@ class RemoteInfo:
     resources: dict or Resources
         expyre.resources.Resources or kwargs for its constructor
     num_inputs_per_queued_job: int, default -100
-        num_inputs_per_python_subprocess for each job. If negative will be multiplied by iterable_autopara_wrappable num_inputs_per_python_subprocess
+        num_inputs_per_python_subprocess for each job. If negative will be multiplied by iterable_autopara_wrappable
+        num_inputs_per_python_subprocess
     pre_cmds: list(str)
         commands to run before starting job
     post_cmds: list(str)
@@ -37,7 +38,7 @@ class RemoteInfo:
     ignore_failed_jobs: bool, default False
         skip failures in remote jobs
     resubmit_killed_jobs: bool, default False
-        resubmit jobs that were killed without an exit status (out of walltime or crashed), 
+        resubmit jobs that were killed without an exit status (out of walltime or crashed),
         hoping that other parameters such as walltime or memory have been changed to make run complete this time
     hash_ignore: list(str), default []
         list of arguments to ignore when doing hash of remote function arguments to determine if it's already been done
@@ -68,4 +69,5 @@ class RemoteInfo:
 
 
     def __str__(self):
-        return f'{self.sys_name} {self.job_name} {self.resources} {self.num_inputs_per_queued_job} {self.exact_fit} {self.partial_node} {self.timeout} {self.check_interval}'
+        return (f'{self.sys_name} {self.job_name} {self.resources} {self.num_inputs_per_queued_job} {self.exact_fit} '
+                f'{self.partial_node} {self.timeout} {self.check_interval}')

--- a/wfl/autoparallelize/utils.py
+++ b/wfl/autoparallelize/utils.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from .remoteinfo import RemoteInfo
 
+
 def grouper(n, iterable):
     """iterator that goes over iterable in specified size groups
 
@@ -47,7 +48,7 @@ def get_remote_info(remote_info, remote_label, env_var="WFL_EXPYRE_INFO"):
     remote_label: str, default None
         remote_label to use for operation, to match to remote_info dict keys.  If none, use calling routine filename '::' calling function
     env_var: str, default "WFL_EXPYRE_INFO"
-        environment var to get information from if not present in `remote\_info` argument
+        environment var to get information from if not present in `remote_info` argument
 
     Returns
     -------
@@ -61,7 +62,8 @@ def get_remote_info(remote_info, remote_label, env_var="WFL_EXPYRE_INFO"):
             remote_info = os.environ[env_var]
             if ' ' in remote_info:
                 # if it's not JSON, it must be a filename, so presence of space is suspicious
-                warnings.warn(f'remote_info "{remote_info}" from WFL_EXPYRE_INFO has whitespace, but not parseable as JSON/YAML with error {exc}')
+                warnings.warn(f'remote_info "{remote_info}" from WFL_EXPYRE_INFO has whitespace, but not parseable as '
+                              f'JSON/YAML with error {exc}')
         if isinstance(remote_info, str):
             # filename
             with open(remote_info) as fin:
@@ -102,6 +104,7 @@ def get_remote_info(remote_info, remote_label, env_var="WFL_EXPYRE_INFO"):
 
     return remote_info
 
+
 def get_root_global_seed(kwargs, op, label):
     """get root global seed from kwargs
 
@@ -118,7 +121,8 @@ def get_root_global_seed(kwargs, op, label):
 
     Returns
     -------
-    root_global_seed: int seed with value kwargs["autopara_rng_seed"] or random int if value is None or not in kwargs, or None if "autopara_rng_seed" is not in op's signature
+    root_global_seed: int seed with value kwargs["autopara_rng_seed"] or random int if value is None or not in
+                      kwargs, or None if "autopara_rng_seed" is not in op's signature
     """
     if "autopara_rng_seed" in inspect.signature(op).parameters:
         if kwargs.get("autopara_rng_seed") is None:

--- a/wfl/calculators/castep.py
+++ b/wfl/calculators/castep.py
@@ -2,28 +2,17 @@
 Quantum Castep interface
 """
 
-import os
-import tempfile
-import subprocess
-import warnings
-import shutil
-import shlex
-
 from copy import deepcopy
-from pathlib import Path
-import numpy as np
 
-from ase import Atoms
 from ase.calculators.calculator import all_changes
 from ase.calculators.castep import Castep as ASE_Castep
 
 from .wfl_fileio_calculator import WFLFileIOCalculator
-from .utils import clean_rundir, handle_nonperiodic, save_results
-from ..utils.misc import atoms_to_list
+from .utils import handle_nonperiodic
 
 # NOMAD compatible, see https://nomad-lab.eu/prod/rae/gui/uploads
 _default_keep_files = ["*.castep", "*.param", "*.cell"]
-_default_properties = ["energy", "forces", "stress"]           
+_default_properties = ["energy", "forces", "stress"]
 
 
 class Castep(WFLFileIOCalculator, ASE_Castep):
@@ -49,7 +38,7 @@ class Castep(WFLFileIOCalculator, ASE_Castep):
     calculator_exec: str
         command for Castep, without any prefix or redirection set.
         for example: "mpirun -n 4 castep.mpi"
-        Alternative for "castep_command", for consistency with other wfl calculators. 
+        Alternative for "castep_command", for consistency with other wfl calculators.
 
     **kwargs: arguments for ase.calculators.Castep.Castep
     """
@@ -67,7 +56,7 @@ class Castep(WFLFileIOCalculator, ASE_Castep):
         if calculator_exec is not None:
             if "castep_command" in kwargs:
                 raise ValueError("Cannot specify both calculator_exec and command")
-            kwargs["castep_command"] = calculator_exec 
+            kwargs["castep_command"] = calculator_exec
 
         if kwargs.get("castep_pp_path", None) is None:
             # make sure we are looking for pspot if path given
@@ -95,23 +84,23 @@ class Castep(WFLFileIOCalculator, ASE_Castep):
 
         try:
             super().calculate(atoms=atoms)
-            calculation_succeeded=True
+            calculation_succeeded = True
             if 'DFT_FAILED_CASTEP' in atoms.info:
                 del atoms.info['DFT_FAILED_CASTEP']
         except Exception as exc:
             atoms.info['DFT_FAILED_CASTEP'] = True
-            calculation_succeeded=False
+            calculation_succeeded = False
             raise exc
         finally:
             # ASE castep calculator does not
-            # always (ever?) raise an exception when it fails.  Instead, you get things like 
+            # always (ever?) raise an exception when it fails.  Instead, you get things like
             # stress being None, which lead to TypeError when save_results calls get_stress().
             for property in properties:
                 result = self.get_property(property)
                 if result is None:
                     calculation_succeeded = False
                     atoms.info["DFT_FAILED_CASTEP"] = True
-            
+
             # from WFLFileIOCalculator
             self.clean_rundir(_default_keep_files, calculation_succeeded)
 
@@ -127,5 +116,4 @@ class Castep(WFLFileIOCalculator, ASE_Castep):
         nonperiodic, properties = handle_nonperiodic(self.atoms, properties)
         self.param.__setattr__("calculate_stress", "stress" in properties)
 
-        return  nonperiodic, properties
-
+        return nonperiodic, properties

--- a/wfl/calculators/espresso.py
+++ b/wfl/calculators/espresso.py
@@ -2,18 +2,11 @@
 Quantum Espresso interface
 """
 
-import os
-import tempfile
-import subprocess
-import warnings
-import shutil
 import shlex
 
 from copy import deepcopy
-from pathlib import Path
 import numpy as np
 
-from ase import Atoms
 from ase.calculators.calculator import all_changes
 from ase.calculators.espresso import Espresso as ASE_Espresso
 try:
@@ -23,8 +16,7 @@ except ImportError:
 from ase.io.espresso import kspacing_to_grid
 
 from .wfl_fileio_calculator import WFLFileIOCalculator
-from .utils import clean_rundir, handle_nonperiodic, save_results
-from ..utils.misc import atoms_to_list
+from .utils import handle_nonperiodic
 
 # NOMAD compatible, see https://nomad-lab.eu/prod/rae/gui/uploads
 _default_keep_files = ["*.pwo"]
@@ -107,12 +99,12 @@ class Espresso(WFLFileIOCalculator, ASE_Espresso):
 
         try:
             super().calculate(atoms=atoms, properties=properties, system_changes=system_changes)
-            calculation_succeeded=True
+            calculation_succeeded = True
             if 'DFT_FAILED_ESPRESSO' in atoms.info:
                 del atoms.info['DFT_FAILED_ESPRESSO']
         except Exception as exc:
             atoms.info['DFT_FAILED_ESPRESSO'] = True
-            calculation_succeeded=False
+            calculation_succeeded = False
             raise exc
         finally:
             # from WFLFileIOCalculator
@@ -172,5 +164,3 @@ class Espresso(WFLFileIOCalculator, ASE_Espresso):
                     self.parameters["koffset"] = k_offset
 
         return properties
-
-

--- a/wfl/calculators/generic.py
+++ b/wfl/calculators/generic.py
@@ -1,5 +1,4 @@
 import warnings
-import functools
 
 from ase import Atoms
 from ase.calculators.calculator import all_changes

--- a/wfl/calculators/mopac.py
+++ b/wfl/calculators/mopac.py
@@ -7,10 +7,12 @@ from ase.calculators.calculator import all_changes
 from .wfl_fileio_calculator import WFLFileIOCalculator
 
 _default_keep_files = ["*.out"]
-_default_properties = ["energy", "forces"] 
+_default_properties = ["energy", "forces"]
 
 class MOPAC(WFLFileIOCalculator, ASE_MOPAC):
-    """ Extension of ASE's MOPAC claculator so that it can be used by wfl.calculators.generic (mainly each calculation is run in a separate directory)"""
+    """Extension of ASE's MOPAC claculator so that it can be used by wfl.calculators.generic (mainly each
+    calculation is run in a separate directory)
+    """
 
     wfl_generic_default_autopara_info = {"num_inputs_per_python_subprocess": 1}
 
@@ -33,14 +35,13 @@ class MOPAC(WFLFileIOCalculator, ASE_MOPAC):
 
         try:
             super().calculate(atoms=atoms, properties=properties, system_changes=system_changes)
-            calculation_succeeded=True
+            calculation_succeeded = True
             if 'FAILED_MOPAC' in atoms.info:
                 del atoms.info['FAILED_MOPAC']
         except Exception as exc:
             atoms.info['FAILED_MOPAC'] = True
-            calculation_succeeded=False
+            calculation_succeeded = False
             raise exc
         finally:
             # from WFLFileIOCalculator
             self.clean_rundir(_default_keep_files, calculation_succeeded)
-

--- a/wfl/calculators/orca/__init__.py
+++ b/wfl/calculators/orca/__init__.py
@@ -1,9 +1,6 @@
 import os
 import re
-import shutil
-import tempfile
-import warnings
-from pathlib import Path 
+from pathlib import Path
 import subprocess
 
 import ase.io
@@ -15,8 +12,7 @@ from ase.calculators.calculator import CalculationFailed, Calculator, \
 from ase.calculators.orca import ORCA as ASE_ORCA
 
 from ..wfl_fileio_calculator import WFLFileIOCalculator
-from wfl.calculators.utils import clean_rundir, save_results
-from wfl.utils.misc import atoms_to_list, chunks
+from wfl.utils.misc import chunks
 
 
 _default_keep_files = ["*.inp", "*.out", "*.ase", "*.engrad", "*.xyz",
@@ -28,10 +24,10 @@ class ORCA(WFLFileIOCalculator, ASE_ORCA):
 
     Notes
     -----
-        - "directory" argument cannot be present. Use rundir_prefix and workdir instead. 
+        - "directory" argument cannot be present. Use rundir_prefix and workdir instead.
         - Unless specified, multiplicity is set to singlet/doublet for
           closed-/open-shell structures
-        - Results from additional optimisation task (set to "opt" or "copt") are stored in `extra_results` dictionary. 
+        - Results from additional optimisation task (set to "opt" or "copt") are stored in `extra_results` dictionary.
 
     Parameters
     ----------
@@ -52,16 +48,16 @@ class ORCA(WFLFileIOCalculator, ASE_ORCA):
         command for ORCA, without any prefix or redirection set.
         for example: "/path/to/orca"
         mutually exclusive with "command"
-    post_process: function that takes the current instance of the calculator and is to be 
-        executed after reading back results from file, but before all the files are deleted. 
-        For example, a localisation scheme that uses the wavefunction files and saves local 
-        charges to `ORCA.extra_results`. 
+    post_process: function that takes the current instance of the calculator and is to be
+        executed after reading back results from file, but before all the files are deleted.
+        For example, a localisation scheme that uses the wavefunction files and saves local
+        charges to `ORCA.extra_results`.
 
     **kwargs: arguments for ase.calculators.espresso.Espresso
     """
 
     implemented_properties = ["energy", "forces", "dipole"]
-    
+
     # new default value of num_inputs_per_python_subprocess for calculators.generic,
     # to override that function's built-in default of 10
     wfl_generic_default_autopara_info = {"num_inputs_per_python_subprocess": 1}
@@ -85,7 +81,7 @@ class ORCA(WFLFileIOCalculator, ASE_ORCA):
             self.command = f'{calculator_exec} PREFIX.inp > ' \
                            f'PREFIX.out'
         elif calculator_exec is None and "command" not in kwargs:
-            self.command = os.environ.pop("ASE_ORCA_COMMAND", "orca PREFIX.inp > PREFIX.out")
+            self.command = os.environ.get("ASE_ORCA_COMMAND", "orca PREFIX.inp > PREFIX.out")
         else:
             self.command = kwargs["command"]
 
@@ -97,11 +93,11 @@ class ORCA(WFLFileIOCalculator, ASE_ORCA):
         self.extra_results["atoms"] = {}
         self.extra_results["config"] = {}
 
-        self.post_process = post_process 
+        self.post_process = post_process
 
 
     def calculate(self, atoms=None, properties=["energy", "forces"], system_changes=all_changes):
-        """Does the calculation. Handles the working directories in addition to regular 
+        """Does the calculation. Handles the working directories in addition to regular
         ASE calculation operations (writing input, executing, reading_results) """
 
         Calculator.calculate(self, atoms, properties, system_changes)
@@ -115,13 +111,13 @@ class ORCA(WFLFileIOCalculator, ASE_ORCA):
             self.read_results()
             if self.post_process is not None:
                 self.post_process(self)
-            calculation_succeeded=True
+            calculation_succeeded = True
         except Exception as e:
-            calculation_succeeded=False
+            calculation_succeeded = False
             raise e
         finally:
-            # when exception is raised, `calculation_succeeded` is set to False, 
-            # the following code is executed and exception is re-raised. 
+            # when exception is raised, `calculation_succeeded` is set to False,
+            # the following code is executed and exception is re-raised.
             # from WFLFileIOCalculator
             self.clean_rundir(_default_keep_files, calculation_succeeded)
 
@@ -175,7 +171,7 @@ class ORCA(WFLFileIOCalculator, ASE_ORCA):
                         str(atom.position[1]) + ' ' +
                         str(atom.position[2]) + '\n')
             f.write('*\n')
-    
+
     def pick_task(self):
         # energy and force calculation is enforced
         task = self.parameters["task"]
@@ -238,7 +234,7 @@ class ORCA(WFLFileIOCalculator, ASE_ORCA):
         -----
         Each comment line in output xyz has "Coordinates from ORCA-job orca
         E -154.812399026326";
-        # TODO parse out forces as well 
+        # TODO parse out forces as well
         """
         opt_trj = ase.io.read(f'{self.label}_trj.xyz', ':')
         for at in opt_trj:
@@ -255,9 +251,9 @@ class ORCA(WFLFileIOCalculator, ASE_ORCA):
 
         self.extra_results["opt_trajectory"] = opt_trj
 
-    # EG: The eigenvector reading is implemented incorrectly 
+    # EG: The eigenvector reading is implemented incorrectly
     def read_frequencies(self):
-        """Reads frequencies (dynamical matrix eigenvalues) and normal modes (eigenvectors) from output. 
+        """Reads frequencies (dynamical matrix eigenvalues) and normal modes (eigenvectors) from output.
         Currently broken. """
         raise NotImplementedError("Normal mode (eigenvector) parsing is broken")
         with open(self.label + '.out', mode='r', encoding='utf-8') as fd:
@@ -402,7 +398,8 @@ def natural_population_analysis(janpa_home_dir, orca_calc):
     subprocess.run(command, shell=True)     # think about how to handle errors, etc
 
     # 2. Clean up molden format
-    command = f"java -jar {janpa_home_dir / 'molden2molden.jar'} -i {label}.molden.input -o {label}.molden.cleanedup -fromorca3bf -orca3signs > {label}.molden2molden.stdout"
+    command = (f"java -jar {janpa_home_dir / 'molden2molden.jar'} -i {label}.molden.input -o {label}.molden.cleanedup "
+               f"-fromorca3bf -orca3signs > {label}.molden2molden.stdout")
     subprocess.run(command, shell=True)
 
     # 3. Run natural population analysis
@@ -410,10 +407,10 @@ def natural_population_analysis(janpa_home_dir, orca_calc):
     command = f'java -jar {janpa_home_dir / "janpa.jar"} -i {label}.molden.cleanedup > {npa_output}'
     subprocess.run(command, shell=True)
 
-    # 4. Save results 
+    # 4. Save results
     elements, electron_pop, npa_charge = parse_npa_output(npa_output)
-    assert np.all([v1==v2 for v1, v2 in zip(elements, ref_elements)])
-    orca_calc.extra_results["atoms"]["NPA_electron_population"] = electron_pop 
+    assert np.all([v1 == v2 for v1, v2 in zip(elements, ref_elements)])
+    orca_calc.extra_results["atoms"]["NPA_electron_population"] = electron_pop
     orca_calc.extra_results["atoms"]["NPA_charge"] = npa_charge
 
 
@@ -428,7 +425,7 @@ def parse_npa_output(fname):
 
     elements = []
     electron_pop = []
-    npa_charge = [] 
+    npa_charge = []
 
     block = pattern_npa_block.findall(text)[0]
     for line in block.split('\n'):
@@ -440,6 +437,3 @@ def parse_npa_output(fname):
             npa_charge.append(float(values[2]))
 
     return elements, np.array(electron_pop), np.array(npa_charge)
-
-
-

--- a/wfl/calculators/orca/basinhopping.py
+++ b/wfl/calculators/orca/basinhopping.py
@@ -10,7 +10,7 @@ from ase.calculators.calculator import all_changes, CalculationFailed
 from ase.calculators.calculator import Calculator
 
 from wfl.calculators import orca
-from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
+# from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 
 
 def evaluate_basin_hopping(*args, **kwargs):
@@ -135,7 +135,7 @@ class BasinHoppingORCA(Calculator):
                  orcasimpleinput='UHF PBE def2-SVP tightscf', orcablocks=None,
                  orca_command='orca',
                  keep_files=False, uhf=True, **kwargs):
- 
+
         super(BasinHoppingORCA, self).__init__(atoms=atoms, **kwargs)
 
         # calculator settings

--- a/wfl/calculators/utils.py
+++ b/wfl/calculators/utils.py
@@ -68,7 +68,7 @@ def save_results(atoms, properties, results_prefix=None):
 
     # this would be simpler if we could just use calc.results, but some (e.g. Castep) don't use it
     if properties is None:
-        # This will not work for calculators like Castep that (as of some point at least) do not use 
+        # This will not work for calculators like Castep that (as of some point at least) do not use
         # results dict.  Such calculators will fail below, in the "if 'energy' in properties" statement.
         properties = list(atoms.calc.results.keys())
 
@@ -94,7 +94,7 @@ def save_results(atoms, properties, results_prefix=None):
         try:
             config_results['stress'] = atoms.get_stress()
         except PropertyNotImplementedError:
-            warnings.warn(f'"stress" was asked for, but not found in results.')
+            warnings.warn('"stress" was asked for, but not found in results.')
     if 'dipole' in properties:
         config_results['dipole'] = atoms.get_dipole_moment()
     if 'magmom' in properties:
@@ -112,7 +112,7 @@ def save_results(atoms, properties, results_prefix=None):
         atoms_results['magmoms'] = atoms.get_magnetic_moments()
     if 'energies' in properties:
         atoms_results['energies'] = atoms.get_potential_energies()
-    if 'converged' in properties and results_prefix != None:
+    if 'converged' in properties and results_prefix is not None:
         config_results['converged'] = atoms.get_calculator().read_convergence()
 
     if "extra_results" in dir(atoms.calc):
@@ -120,7 +120,7 @@ def save_results(atoms, properties, results_prefix=None):
                                        len(atoms.calc.extra_results.get("atoms", {})) > 0):
             raise ValueError('Refusing to save calculator results into info/arrays fields with no prefix,'
                             ' too much chance of confusion with ASE extxyz reading/writing and conversion'
-                            ' to SinglePointCalculator') 
+                            ' to SinglePointCalculator')
 
         for key, vals in atoms.calc.extra_results["config"].items():
             config_results[key] = vals

--- a/wfl/calculators/vasp.py
+++ b/wfl/calculators/vasp.py
@@ -4,14 +4,11 @@ VASP calculator
 """
 
 import os
-from pathlib import Path
 
 import json
-from copy import deepcopy
 
 import numpy as np
 
-from ase.atoms import Atoms
 from ase.calculators.calculator import all_changes
 from ase.calculators.vasp.vasp import Vasp as ASE_Vasp
 
@@ -70,7 +67,7 @@ class Vasp(WFLFileIOCalculator, ASE_Vasp):
                  workdir=None, scratchdir=None,
                  calculator_exec=None, calculator_exec_gamma=None,
                  **kwargs):
-        
+
         # get initialparams from env var
         kwargs_use = {}
         if 'WFL_VASP_KWARGS' in os.environ:
@@ -136,7 +133,7 @@ class Vasp(WFLFileIOCalculator, ASE_Vasp):
         if nonperiodic:
             self.float_params["kspacing"] = 100000.0
             self.bool_params["kgamma"] = True
-        
+
 
     def per_config_restore(self, atoms):
         # undo pbc change
@@ -155,7 +152,7 @@ class Vasp(WFLFileIOCalculator, ASE_Vasp):
 
 
     def calculate(self, atoms=None, properties=_default_properties, system_changes=all_changes):
-        """Do the calculation. Handles the working directories in addition to regular 
+        """Do the calculation. Handles the working directories in addition to regular
         ASE calculation operations (writing input, executing, reading_results)"""
 
         if atoms is not None:

--- a/wfl/calculators/wfl_fileio_calculator.py
+++ b/wfl/calculators/wfl_fileio_calculator.py
@@ -10,11 +10,11 @@ from ase.calculators.castep import Castep as ASE_Castep
 class WFLFileIOCalculator():
     """Mixin class implementing some methods that should be available to every
     WFL calculator that does I/O via files, i.e. DFT calculators
-    
+
     As a python mixin class, must be inherited from by the wrapping wfl calculator class _before_ the ASE calculator, i.e.
-    
+
     .. code-block:: python
-    
+
         from ase.calculators.dftcode import DftCodeCalculator as ASE_DftCodeCalculator
         class DftCodeCalculator(WFLFileIOCalculator, ASE_DftCodeCalculator):
             .
@@ -71,9 +71,9 @@ class WFLFileIOCalculator():
         else:
             directory = self._cur_rundir
 
-        # ASE's Castep unconventionally uses `_directory` and has its own setter  
+        # ASE's Castep unconventionally uses `_directory` and has its own setter
         # and getter functions that only allows setting non-preditermined attributes
-        # if they start with an underscore.  
+        # if they start with an underscore.
         if isinstance(self, ASE_Castep):
             self._directory = directory
         else:
@@ -81,13 +81,13 @@ class WFLFileIOCalculator():
 
     def clean_rundir(self, _default_keep_files, calculation_succeeded):
 
-        # ASE's Castep unconventionally uses `_directory` and has its own setter  
+        # ASE's Castep unconventionally uses `_directory` and has its own setter
         # and getter functions that only allows setting non-preditermined attributes
         # if they start with an underscore.
         if isinstance(self, ASE_Castep):
-            directory = self._directory 
+            directory = self._directory
         else:
-            directory = self.directory 
+            directory = self.directory
 
         utils_clean_rundir(directory, self._wfl_keep_files, _default_keep_files, calculation_succeeded)
         if self._wfl_scratchdir is not None:

--- a/wfl/cli/cli.py
+++ b/wfl/cli/cli.py
@@ -45,7 +45,7 @@ subcli_select.add_command(by_lambda)
 def subcli_eval(ctx):
     pass
 
-from wfl.cli.commands.eval import gap, ace, mace, atomization_energy 
+from wfl.cli.commands.eval import gap, ace, mace, atomization_energy
 subcli_eval.add_command(gap)
 subcli_eval.add_command(ace)
 subcli_eval.add_command(mace)
@@ -57,7 +57,5 @@ subcli_eval.add_command(atomization_energy)
 def subcli_descriptor(ctx):
     pass
 
-from wfl.cli.commands.descriptor import quippy 
+from wfl.cli.commands.descriptor import quippy
 subcli_descriptor.add_command(quippy)
-
-

--- a/wfl/cli/cli_options.py
+++ b/wfl/cli/cli_options.py
@@ -9,7 +9,7 @@ def _to_ConfigSet(ctx, param, value):
 def inputs(f):
     """Add a standard option for the ConfigSet inputs"""
     f = click.option("--inputs", "-i", required=True, multiple=True, callback=_to_ConfigSet,
-                    help='Input xyz file(s) to create ConfigSet from')(f) 
+                    help='Input xyz file(s) to create ConfigSet from')(f)
     return f
 
 
@@ -39,13 +39,13 @@ def param_fname(f):
     return f
 
 def prop_prefix(f):
-    f = click.option("--prop-prefix", "-pp", help='Prefix to be pre-pended to all evaluate properties. Defaults to "gap_"/"ace_"/"mace_" as appropriate')(f)
+    f = click.option("--prop-prefix", "-pp", help='Prefix to be pre-pended to all evaluate properties. '
+                                                  'Defaults to "gap_"/"ace_"/"mace_" as appropriate')(f)
     return f
 
 
 def num_inputs_per_python_subprocess(f):
-    f = click.option('--num-inputs-per-python-subprocess', default=10, 
-    show_default=True, type=click.INT, 
+    f = click.option('--num-inputs-per-python-subprocess', default=10,
+    show_default=True, type=click.INT,
     help="Number of configs to be evaluated per each calculator initialization")(f)
     return f
-

--- a/wfl/cli/commands/error.py
+++ b/wfl/cli/commands/error.py
@@ -1,48 +1,46 @@
 import click
-import pandas as pd
-import numpy as np
 from wfl.cli import cli_options as opt
 from wfl.fit.error import calc as ref_err_calc
 from wfl.fit.error import value_error_scatter, errors_dumps
 
 
 @click.command("error")
-@click.option('--calc-property-prefix', '-cpp', required=True, 
+@click.option('--calc-property-prefix', '-cpp', required=True,
     help="prefix for calculated (predicted) properties (energy, forces, ...)")
-@click.option("--ref-property-prefix", '-rpp', required=True, 
+@click.option("--ref-property-prefix", '-rpp', required=True,
     help="prefix for properties taken as reference (e.g. from electronic structure codes)")
-@click.option("--config-properties", '-cp', multiple=True, 
-    help="Multiple ``Atoms.info`` calculated properties (to be prefixed by ``ref_property_prefix`` or ``calc_property_prefix``) to"\
-         " compute error for.  ``virial`` will be reconstructed from ``stress``. Properties can end with ``/atom`` or "\
-         " ``/comp`` for different components being counted separately. Default of [\"energy/atom\", \"virial/atom/comp\"]only used if neither ``config_properties``"\
-         " nor ``atom_properties`` is present.")
-@click.option("--atom-properties", '-ap', multiple=True, 
-    help="Multiple `Atoms.arrays` calculated properties (to be prefixed by ``ref_property_prefix``"\
-         "or ``calc_property_prefix``) to compute error For.  Properties can end with ``/comp``"\
-         "for different components being computed separately, and ``/Z`` for different atomic numbers"\
-         "to be assigned to different categories.  Default of [\"forces\"] only used if neither ``config_properties``"\
-         "nor ``atom_properties`` is present.")
+@click.option("--config-properties", '-cp', multiple=True,
+    help='Multiple ``Atoms.info`` calculated properties (to be prefixed by ``ref_property_prefix`` or ``calc_property_prefix``) to'
+         ' compute error for.  ``virial`` will be reconstructed from ``stress``. Properties can end with ``/atom`` or '
+         ' ``/comp`` for different components being counted separately. Default of ["energy/atom", "virial/atom/comp"] '
+         ' only used if neither ``config_properties`` nor ``atom_properties`` is present.')
+@click.option("--atom-properties", '-ap', multiple=True,
+    help='Multiple `Atoms.arrays` calculated properties (to be prefixed by ``ref_property_prefix``'
+         'or ``calc_property_prefix``) to compute error For.  Properties can end with ``/comp``'
+         'for different components being computed separately, and ``/Z`` for different atomic numbers'
+         'to be assigned to different categories.  Default of ["forces"] only used if neither ``config_properties``'
+         'nor ``atom_properties`` is present.')
 @click.option("--category-keys", '-ck', multiple=True, default=["config_type"], show_default=True,
-    help="Results will be averaged by a category, defined by a string containing the values of these"\
+    help="Results will be averaged by a category, defined by a string containing the values of these"
          "keys in Atoms.info, in addition to overall average _ALL_ category.")
 @click.option("--weight-property", '-wp', help="Atoms.info key for weights to apply to RMSE calculation")
 @click.option("--precision", '-p', type=click.INT, default=2, help="precision for printing table")
 @click.option("--fig-name", "-f", help="Filename for figure. Do not plot if not given. ")
-@click.option("--error-type", default="RMSE", show_default=True, type=click.Choice(["RMSE", "MAE"]), 
+@click.option("--error-type", default="RMSE", show_default=True, type=click.Choice(["RMSE", "MAE"]),
     help="Which error to report in legend")
 @click.option("--cmap", help="Colormap to use for plot if not default")
 @click.pass_context
 @opt.inputs
-def show_error(ctx, inputs, calc_property_prefix, ref_property_prefix, 
+def show_error(ctx, inputs, calc_property_prefix, ref_property_prefix,
           config_properties, atom_properties, category_keys,
-          weight_property, precision, fig_name, error_type, 
+          weight_property, precision, fig_name, error_type,
           cmap):
     """Prints error summary table"""
     # TODO
     # - clean up cmap
 
     errors, diffs, parity = ref_err_calc(
-        inputs=inputs, 
+        inputs=inputs,
         calc_property_prefix=calc_property_prefix,
         ref_property_prefix=ref_property_prefix,
         config_properties=config_properties,
@@ -50,20 +48,17 @@ def show_error(ctx, inputs, calc_property_prefix, ref_property_prefix,
         category_keys=category_keys,
         weight_property=weight_property)
 
-    # print(errors) 
+    # print(errors)
     print(errors_dumps(errors, error_type, precision))
 
     if fig_name:
 
         value_error_scatter(
-            all_errors = errors, 
+            all_errors=errors,
             all_diffs=diffs,
             all_parity=parity,
             output=fig_name,
             ref_property_prefix=ref_property_prefix,
             calc_property_prefix=calc_property_prefix,
-            error_type = error_type,
-            cmap=cmap
-        )
-
-
+            error_type=error_type,
+            cmap=cmap)

--- a/wfl/cli/commands/eval.py
+++ b/wfl/cli/commands/eval.py
@@ -17,18 +17,18 @@ from wfl.utils import configs
 @opt.num_inputs_per_python_subprocess
 def gap(ctx, inputs, outputs, param_fname, prop_prefix, num_inputs_per_python_subprocess):
     """evaluates GAP"""
-    
-    if prop_prefix is None:
-        prop_prefix="gap_"
 
-    calc = (Potential, [], {"param_filename":param_fname})
+    if prop_prefix is None:
+        prop_prefix = "gap_"
+
+    calc = (Potential, [], {"param_filename": param_fname})
 
     generic.calculate(
-        inputs=inputs, 
+        inputs=inputs,
         outputs=outputs,
         calculator=calc,
-        output_prefix=prop_prefix, 
-        autopara_info=AutoparaInfo(num_inputs_per_python_subprocess = num_inputs_per_python_subprocess))
+        output_prefix=prop_prefix,
+        autopara_info=AutoparaInfo(num_inputs_per_python_subprocess=num_inputs_per_python_subprocess))
 
 
 def pyjulip_ace(param_fname):
@@ -52,15 +52,16 @@ def ace(ctx, inputs, outputs, param_fname, prop_prefix, num_inputs_per_python_su
     calc = (pyjulip_ace, [param_fname], {})
 
     generic.calculate(
-        inputs=inputs, 
+        inputs=inputs,
         outputs=outputs,
         calculator=calc,
-        output_prefix=prop_prefix, 
-        autopara_info=AutoparaInfo(num_inputs_per_python_subprocess = num_inputs_per_python_subprocess))
+        output_prefix=prop_prefix,
+        autopara_info=AutoparaInfo(num_inputs_per_python_subprocess=num_inputs_per_python_subprocess))
 
 
 @click.command("mace")
-@click.option("--dtype", default="float64", type=click.Choice(["float64", "float32"]), show_default=True, help="dtype MACE model was fitted with")
+@click.option("--dtype", default="float64", type=click.Choice(["float64", "float32"]), show_default=True,
+              help="dtype MACE model was fitted with")
 @click.pass_context
 @opt.inputs
 @opt.outputs
@@ -70,16 +71,16 @@ def ace(ctx, inputs, outputs, param_fname, prop_prefix, num_inputs_per_python_su
 def mace(ctx, inputs, outputs, param_fname, prop_prefix, num_inputs_per_python_subprocess, dtype):
     """evaluates MACE"""
 
-    from mace.calculators.mace import MACECalculator 
+    from mace.calculators.mace import MACECalculator
 
-    calc = (MACECalculator, [], {"model_path":param_fname, "default_dtype":dtype, "device":'cpu'})
+    calc = (MACECalculator, [], {"model_path": param_fname, "default_dtype": dtype, "device": 'cpu'})
 
     generic.calculate(
-        inputs=inputs, 
+        inputs=inputs,
         outputs=outputs,
         calculator=calc,
-        output_prefix=prop_prefix, 
-        autopara_info=AutoparaInfo(num_inputs_per_python_subprocess = num_inputs_per_python_subprocess))
+        output_prefix=prop_prefix,
+        autopara_info=AutoparaInfo(num_inputs_per_python_subprocess=num_inputs_per_python_subprocess))
 
 
 @click.command("atomization-energy")
@@ -87,11 +88,11 @@ def mace(ctx, inputs, outputs, param_fname, prop_prefix, num_inputs_per_python_s
 @opt.inputs
 @opt.outputs
 @opt.prop_prefix
-@click.option("--prop", default="energy", show_default=True, 
+@click.option("--prop", default="energy", show_default=True,
     help="Property to calculate atomization value for")
-@click.option("--isolated-atom-info-key", "-k", default="config_type", show_default=True, 
+@click.option("--isolated-atom-info-key", "-k", default="config_type", show_default=True,
     help="``atoms.info`` key on which to select isolated atoms")
-@click.option("--isolated-atom-info-value", "-v", default="default", 
+@click.option("--isolated-atom-info-value", "-v", default="default",
     help="``atoms.info['isolated_atom_info_key']`` value for isolated atoms. Defaults to \"IsolatedAtom\" or \"isolated_atom\"")
 def atomization_energy(inputs, outputs, prop_prefix, prop, isolated_atom_info_key, isolated_atom_info_value):
     configs.atomization_energy(
@@ -100,7 +101,4 @@ def atomization_energy(inputs, outputs, prop_prefix, prop, isolated_atom_info_ke
         prop_prefix=prop_prefix,
         property=prop,
         isolated_atom_info_key=isolated_atom_info_key,
-        isolated_atom_info_value=isolated_atom_info_value
-    )
-
-
+        isolated_atom_info_value=isolated_atom_info_value)

--- a/wfl/cli/commands/generate.py
+++ b/wfl/cli/commands/generate.py
@@ -61,9 +61,4 @@ def buildcell(ctx, outputs, buildcell_input, buildcell_exec, n_configs,
         buildcell_input=buildcell_input_txt,
         extra_info=extra_info,
         perturbation=perturbation,
-        verbose=ctx.obj["verbose"]
-    )
-
-
-
-
+        verbose=ctx.obj["verbose"])

--- a/wfl/cli/commands/select.py
+++ b/wfl/cli/commands/select.py
@@ -1,10 +1,9 @@
-from pathlib import Path
 import click
 from wfl.cli import cli_options as opt
-from wfl.configset import ConfigSet, OutputSpec
 import wfl.descriptors.quippy
 import wfl.select.by_descriptor
 from wfl.select.simple import by_bool_func
+
 
 @click.command("cur")
 @click.option("--n-configs", "-N", type=click.INT, required=True,
@@ -19,7 +18,7 @@ from wfl.select.simple import by_bool_func
 @opt.outputs
 def cur(ctx, inputs, outputs, n_configs, key, keep_descriptor,
                 kernel_exponent, deterministic, stochastic_seed):
-    """Select structures by CUR"""    
+    """Select structures by CUR"""
 
     wfl.select.by_descriptor.CUR_conf_global(
         inputs=inputs,
@@ -27,12 +26,11 @@ def cur(ctx, inputs, outputs, n_configs, key, keep_descriptor,
         num=n_configs,
         at_descs_info_key=key, kernel_exp=kernel_exponent, stochastic=not deterministic,
         keep_descriptor_info=keep_descriptor,
-        stochastic_seed=stochastic_seed
-        )
+        stochastic_seed=stochastic_seed)
 
 
 @click.command("lambda")
-@click.option("--exec-code", "-e", required=True, 
+@click.option("--exec-code", "-e", required=True,
 help='String to be evaluated by the lambda function. Will be substituted into `eval(\"lambda atoms: \" + exec_code)`.')
 @click.pass_context
 @opt.inputs
@@ -45,7 +43,4 @@ def by_lambda(ctx, inputs, outputs, exec_code):
     by_bool_func(
         inputs=inputs,
         outputs=outputs,
-        at_filter=at_filter_fun
-    )
-
-    
+        at_filter=at_filter_fun)

--- a/wfl/cli/dft_convergence_test.py
+++ b/wfl/cli/dft_convergence_test.py
@@ -70,12 +70,12 @@ def cli(verbose, configuration, buildcell_inputs, buildcell_cmd, n_per_config, p
             evaluated_structs = OutputSpec(f'DFT_evaluated.{key}_{param_val}.xyz', file_root=run_dir)
 
             dft_evaluated[key][param_val] = evaluate_dft(
-                    inputs=structs, outputs=evaluated_structs,
-                    calculator_name=params['calculator'],
-                    workdir_root=os.path.join(run_dir, 'vasp_run'),
-                    calculator_kwargs=run_kwargs,
-                    output_prefix=output_prefix,
-                    keep_files='default' if verbose else False)
+                inputs=structs, outputs=evaluated_structs,
+                calculator_name=params['calculator'],
+                workdir_root=os.path.join(run_dir, 'vasp_run'),
+                calculator_kwargs=run_kwargs,
+                output_prefix=output_prefix,
+                keep_files='default' if verbose else False)
 
     print('E in eV/atom, F in eV/A, stress in GPa')
     print('"dX" is maximum over configs, atoms, and components, "mean" is mean absolute values over same set')

--- a/wfl/cli/gap_rss_iter_fit.py
+++ b/wfl/cli/gap_rss_iter_fit.py
@@ -9,8 +9,6 @@ import wfl.autoparallelize.mpipool_support
 
 wfl.autoparallelize.mpipool_support.init()
 
-import os
-import sys
 import glob
 import json
 import pathlib
@@ -159,7 +157,7 @@ def prep(ctx, length_scales_file, verbose):
     print('length_scales\n' + pprint.pformat(length_scales, indent=2))
 
     # prep buildcell inputs using Zs, compositions, length scales
-    for buildcell_step_type, natom in params.get('prep/buildcell', {'default' : [6, 24]}).items():
+    for buildcell_step_type, natom in params.get('prep/buildcell', {'default': [6, 24]}).items():
         buildcell_inputs = {}
         for c_inds in compositions:
             if verbose:
@@ -376,7 +374,7 @@ def evaluate_ref(dft_in_configs, dft_evaluated_configs, params, run_dir, verbose
         outputs=dft_evaluated_configs,
         calculator=calculator(workdir=run_dir, keep_files=keep_files, **params.dft_params.get("kwargs", {})),
         output_prefix="REF_",
-        autopara_info = {'remote_label': 'REF_eval'}
+        autopara_info={'remote_label': 'REF_eval'}
     )
 
 
@@ -415,7 +413,7 @@ def do_fit_and_test(cur_iter, run_dir, params, fitting_configs, testing_configs=
             at.calc = None
         evaluated_configs = generic.calculate(fitting_configs, co, calculator, output_prefix="GAP_")
         fitting_error = wfl.fit.error.calc(evaluated_configs, calc_property_prefix="GAP_", ref_property_prefix="REF_",
-                category_keys = ['config_type', 'gap_rss_iter'])
+                category_keys=['config_type', 'gap_rss_iter'])
         with open(GAP_xml_file + '.fitting_err.json', 'w') as fout:
             json.dump(dict_tuple_keys_to_str(fitting_error[0]), fout)
         print('FITTING ERROR')
@@ -426,7 +424,7 @@ def do_fit_and_test(cur_iter, run_dir, params, fitting_configs, testing_configs=
             at.calc = None
         evaluated_configs = generic.calculate(testing_configs, co, calculator, output_prefix="GAP_")
         testing_error = wfl.fit.error.calc(evaluated_configs, calc_property_prefix="GAP_", ref_property_prefix="REF_",
-                category_keys = ['config_type', 'gap_rss_iter'])
+                category_keys=['config_type', 'gap_rss_iter'])
         with open(GAP_xml_file + '.testing_err.json', 'w') as fout:
             json.dump(dict_tuple_keys_to_str(testing_error[0]), fout)
         print('TESTING ERROR')
@@ -526,7 +524,7 @@ def get_buildcell_input_files(step_label, cur_iter):
     if use_filename is None:
         # look for non-iter-specific file
         for filename in files:
-            if filename.endswith(f".{step_label}.yaml") or filename.endswith(f".default.yaml"):
+            if filename.endswith(f".{step_label}.yaml") or filename.endswith(".default.yaml"):
                 use_filename = filename
                 break
 
@@ -578,13 +576,13 @@ def do_initial_step(ctx, cur_iter, verbose):
 
     atoms_dimers = ConfigSet('atoms_and_dimers.xyz')
 
-    GAP_xml_file = evaluate_iter_and_fit_all(cur_iter, run_dir, params, Params(params.get('initial_step'), cur_iter),
-                                             [grp['cur_confs'] for grp in groups.values()] + [atoms_dimers],
-                                             [grp['testing_confs'] for grp in groups.values()],
-                                             params.get('fit/database_modify_mod'),
-                                             params.get('fit/calc_fitting_error', default=True),
-                                             extra_fitting_files=params.get('fit/extra_fitting_files', default=[]),
-                                             seeds=ctx.obj['seeds'], verbose=verbose)
+    _ = evaluate_iter_and_fit_all(cur_iter, run_dir, params, Params(params.get('initial_step'), cur_iter),
+                                  [grp['cur_confs'] for grp in groups.values()] + [atoms_dimers],
+                                  [grp['testing_confs'] for grp in groups.values()],
+                                  params.get('fit/database_modify_mod'),
+                                  params.get('fit/calc_fitting_error', default=True),
+                                  extra_fitting_files=params.get('fit/extra_fitting_files', default=[]),
+                                  seeds=ctx.obj['seeds'], verbose=verbose)
 
     print_log('done')
     increment_active_iter(cur_iter)
@@ -635,13 +633,13 @@ def do_rss_step(ctx, cur_iter, verbose):
                                           params.get('global/config_selection_descriptor_local', default=False),
                                           verbose=verbose)
 
-    GAP_xml_file = evaluate_iter_and_fit_all(cur_iter, run_dir, params, Params(params.get('rss_step'), cur_iter),
-                                             [grp['cur_confs'] for grp in groups.values()],
-                                             [grp['testing_confs'] for grp in groups.values()],
-                                             params.get('fit/database_modify_mod'),
-                                             params.get('fit/calc_fitting_error', default=True),
-                                             extra_fitting_files=params.get('fit/extra_fitting_files', default=[]),
-                                             seeds=ctx.obj['seeds'], verbose=verbose)
+    _ = evaluate_iter_and_fit_all(cur_iter, run_dir, params, Params(params.get('rss_step'), cur_iter),
+                                  [grp['cur_confs'] for grp in groups.values()],
+                                  [grp['testing_confs'] for grp in groups.values()],
+                                  params.get('fit/database_modify_mod'),
+                                  params.get('fit/calc_fitting_error', default=True),
+                                  extra_fitting_files=params.get('fit/extra_fitting_files', default=[]),
+                                  seeds=ctx.obj['seeds'], verbose=verbose)
 
     print_log('done')
     increment_active_iter(cur_iter)
@@ -662,8 +660,10 @@ def do_MD_bulk_defect_step(ctx, cur_iter, minima_file, verbose):
     run_dir, Zs, compositions = step_startup(params, cur_iter)
 
     single_composition_group = params.get('global/single_composition_group', default=True)
-    minima_select_by_desc_method = params.get('MD_bulk_defect_step/prelim_select_by_desc_method', default=params.get('global/prelim_select_by_desc_method', default='CUR'))
-    select_by_desc_method = params.get('MD_bulk_defect_step/select_by_desc_method', default=params.get('global/select_by_desc_method', default='CUR'))
+    minima_select_by_desc_method = params.get('MD_bulk_defect_step/prelim_select_by_desc_method',
+                                              default=params.get('global/prelim_select_by_desc_method', default='CUR'))
+    select_by_desc_method = params.get('MD_bulk_defect_step/select_by_desc_method',
+                                       default=params.get('global/select_by_desc_method', default='CUR'))
     with open('gap_rss_iter_fit.prep.config_selection_descriptors.yaml') as fin:
         descriptor_strs = yaml.safe_load(fin)
 
@@ -787,7 +787,7 @@ def do_MD_bulk_defect_step(ctx, cur_iter, minima_file, verbose):
             defect_starting = wfl.select.simple.by_bool_func(defect_optimize_trajs,
                                                              OutputSpec(f'defect_minima.{grp_label}.xyz',
                                                                         file_root=run_dir),
-                                                             lambda at : at.info["optimize_config_type"].startswith("optimize_last"))
+                                                             lambda at: at.info["optimize_config_type"].startswith("optimize_last"))
         else:
             defect_starting = groups[grp_label]['defect_confs']
 
@@ -806,13 +806,13 @@ def do_MD_bulk_defect_step(ctx, cur_iter, minima_file, verbose):
         run_dir, cur_iter, groups, Params(params.get('MD_bulk_defect_step'), cur_iter), Zs, 'md_energy', select_by_desc_method,
         descriptor_strs, params.get('global/config_selection_descriptor_local', default=False), verbose=verbose)
 
-    GAP_xml_file = evaluate_iter_and_fit_all(cur_iter, run_dir, params, Params(params.get('MD_bulk_defect_step'), cur_iter),
-                                             [grp['cur_confs'] for grp in groups.values()],
-                                             [grp['testing_confs'] for grp in groups.values()],
-                                             params.get('fit/database_modify_mod'),
-                                             params.get('fit/calc_fitting_error', default=True),
-                                             extra_fitting_files=params.get('fit/extra_fitting_files', default=[]),
-                                             seeds=ctx.obj['seeds'], verbose=verbose)
+    _ = evaluate_iter_and_fit_all(cur_iter, run_dir, params, Params(params.get('MD_bulk_defect_step'), cur_iter),
+                                  [grp['cur_confs'] for grp in groups.values()],
+                                  [grp['testing_confs'] for grp in groups.values()],
+                                  params.get('fit/database_modify_mod'),
+                                  params.get('fit/calc_fitting_error', default=True),
+                                  extra_fitting_files=params.get('fit/extra_fitting_files', default=[]),
+                                  seeds=ctx.obj['seeds'], verbose=verbose)
 
     print_log('done')
     increment_active_iter(cur_iter)
@@ -922,7 +922,7 @@ def RSS_minima_diverse(run_dir, groups, step_params, Zs,
         print_log('selecting minima from trajectories')
         # select minima from trajs
         minima = wfl.select.simple.by_bool_func(trajs, OutputSpec(f'minima.{grp_label}.xyz', file_root=run_dir),
-                                                lambda at : at.info["optimize_config_type"].startswith("optimize_last"))
+                                                lambda at: at.info["optimize_config_type"].startswith("optimize_last"))
 
         if select_convex_hull:
             print_log('selecting convex hull of minima')
@@ -962,7 +962,7 @@ def RSS_minima_diverse(run_dir, groups, step_params, Zs,
             # select all configs for these indices from all trajs
             selected_traj = wfl.select.simple.by_bool_func(
                 trajs, OutputSpec(f'selected_rss_traj.{grp_label}.xyz', file_root=run_dir),
-                lambda at : at.info["buildcell_config_i"] in selected_minima_config_i)
+                lambda at: at.info["buildcell_config_i"] in selected_minima_config_i)
 
             groups[grp_label]['cur_confs'] = selected_traj
 

--- a/wfl/configset.py
+++ b/wfl/configset.py
@@ -1,7 +1,6 @@
 import sys
 
 from pathlib import Path
-import glob
 
 
 from ase.atoms import Atoms
@@ -20,7 +19,7 @@ class ConfigSet:
     (even of length 1), the top level of nesting returned by the iterators corresponds
     to each file.
 
-    Iterating over the ConfigSet returns a flattened list of configurations in the object, 
+    Iterating over the ConfigSet returns a flattened list of configurations in the object,
     with information about the nested structure (necessary for reproducing it in the
     output, see OutputSpec.store() below) available from the ConfigSet's cur_loc
     property or in the returned returned objects in Atoms.info["_ConfigSet_loc"].
@@ -123,8 +122,7 @@ class ConfigSet:
     def __str__(self):
         """Convert to string
         """
-        code = { Path: "F", Atoms : "A" }
-        out = f"ConfigSet with"
+        out = "ConfigSet with"
 
         if isinstance(self.items, Path):
             out += f" single file {self.items} {self._file_loc}"
@@ -244,7 +242,8 @@ class ConfigSet:
                     # any matching configs
                     raise RuntimeError(f"No matching configs in file {self.items} for location {self._file_loc}") from exc
 
-            ## print("DEBUG after possibly skipping, now should be at right place, at_loc", at_loc, "self._file_loc", self._file_loc, "cur_at_i", cur_at_i, "self._cur_at.numbers", self._cur_at[0].numbers)
+            ## print("DEBUG after possibly skipping, now should be at right place, at_loc", at_loc, "self._file_loc",
+            ##       self._file_loc, "cur_at_i", cur_at_i, "self._cur_at.numbers", self._cur_at[0].numbers)
             # now self._cur_at should be first config that matches self._file_loc
             requested_depth = len(self._file_loc.split(ConfigSet._loc_sep))
             ## print("DEBUG requested_depth", requested_depth)
@@ -273,7 +272,7 @@ class ConfigSet:
                     # get location of deeper iterator from at_loc down to one deeper than requested at this level
                     new_file_loc = ConfigSet._loc_sep.join(at_loc.split(ConfigSet._loc_sep)[0:requested_depth + 1])
                     ## print("DEBUG making and yielding ConfigSet with new _file_loc", new_file_loc)
-                    t = ConfigSet(self.items, _open_reader = self._open_reader, _cur_at = self._cur_at, _file_loc = new_file_loc)
+                    t = ConfigSet(self.items, _open_reader=self._open_reader, _cur_at=self._cur_at, _file_loc=new_file_loc)
                     ## print("DEBUG yielding ConfigSet", t, "_open_reader", t._open_reader, "_cur_at", self._cur_at)
                     yield t
                     ## print("DEBUG after yield, got self._cur_at", self._cur_at[0].numbers if self._cur_at[0] is not None else None)
@@ -305,7 +304,7 @@ class ConfigSet:
                     if "_ConfigSet_loc" in item.info:
                         del item.info["_ConfigSet_loc"]
                     yield item
-                else: # item must be sublist or Path
+                else:  # item must be sublist or Path
                     # yield a ConfigSet for each file or sublist
                     yield ConfigSet(item)
 
@@ -332,7 +331,7 @@ class ConfigSet:
     @staticmethod
     def _flat_iter(items):
         """Generator returning a flattened list of Atoms starting from a tree of nested lists
-        containing only Atoms as leaves. Stores original nested tree structure in 
+        containing only Atoms as leaves. Stores original nested tree structure in
         Atoms.info["_ConfigSet_loc"].
 
         Parameters
@@ -431,7 +430,7 @@ class OutputSpec:
             Configurations to write.  If ConfigSet, location will be saved
         """
         if not self.overwrite and self.all_written():
-            sys.stderr.write(f'Reusing existing output instead of writing ConfigSet contents since overwrite=False and output is done\n')
+            sys.stderr.write('Reusing existing output instead of writing ConfigSet contents since overwrite=False and output is done\n')
             return
 
         for at in configs:
@@ -586,9 +585,9 @@ class OutputSpec:
     def to_ConfigSet(self):
         if self.files is not None:
             if self.single_file:
-                cs = ConfigSet(self.files[0], file_root = self.file_root)
+                cs = ConfigSet(self.files[0], file_root=self.file_root)
             else:
-                cs = ConfigSet(self.files, file_root = self.file_root)
+                cs = ConfigSet(self.files, file_root=self.file_root)
         else:
             cs = ConfigSet(self.configs)
         return cs

--- a/wfl/descriptor_heuristics.py
+++ b/wfl/descriptor_heuristics.py
@@ -121,8 +121,9 @@ def descriptor_2brn_uniform_file(descriptor, ident='', desc_i=0):
 
     Parameters
     ----------
-    descriptor: dict 
-        nested structure with some contained dicts that have 'sparse_method' = '\_2BRN_UNIFORM_FILE\_', and also ``n_sparse``, ``exponents``, ``cutoff``
+    descriptor: dict
+        nested structure with some contained dicts that have 'sparse_method' = '\_2BRN_UNIFORM_FILE\_',
+        and also ``n_sparse``, ``exponents``, ``cutoff``
     ident: str, default ''
         identifier string to add to sparsepoints filename
     desc_i: int, default 0

--- a/wfl/descriptors/quippy.py
+++ b/wfl/descriptors/quippy.py
@@ -6,7 +6,7 @@ from ase.atoms import Atoms
 try:
     from quippy.descriptors import Descriptor
 except ModuleNotFoundError as exc:
-    raise RuntimeError("quippy.descriptors module not found, install with 'python3 -m pip install quippy-ase'")
+    raise RuntimeError("quippy.descriptors module not found, install with 'python3 -m pip install quippy-ase'") from exc
 
 from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 from wfl.utils.quip_cli_strings import dict_to_quip_str
@@ -19,11 +19,11 @@ def from_any_to_Descriptor(descriptor_src, verbose=False):
     ----------
     descriptor_src: desc / list(desc) / dict(Zcenter : desc) / dict(Zcenter : list(desc))
         String to pass to quippy Descriptor. "Zcenter" denotes atomic number of the central atom".
-        Any "desc" value can be a string, a dict (converted to 
-        key=value string), or quippy.descriptors.Descriptor object. 
+        Any "desc" value can be a string, a dict (converted to
+        key=value string), or quippy.descriptors.Descriptor object.
 
-        Each ``descriptor_src`` type correponds to 
-        
+        Each ``descriptor_src`` type correponds to
+
             * a dictionary with None as keys: one or more descriptor for for all species.
             * a dictionary with integers as keys: one or more descriptor for for each species.
             * string, dictionary or ``Descriptor``: single descriptor

--- a/wfl/fit/ace.py
+++ b/wfl/fit/ace.py
@@ -5,7 +5,6 @@ import itertools
 import subprocess
 import json
 import yaml
-import shlex
 from copy import deepcopy
 from pathlib import Path
 
@@ -14,7 +13,7 @@ import numpy as np
 import ase.io
 from ase.stress import voigt_6_to_full_3x3_stress
 
-from wfl.configset import OutputSpec 
+from wfl.configset import OutputSpec
 from wfl.autoparallelize.utils import get_remote_info
 from wfl.fit.utils import ace_fit_jl_path
 from wfl.utils.configs import find_isolated_atoms
@@ -36,7 +35,7 @@ def fit(fitting_configs, ACE_name, ace_fit_params, ace_fit_command=None,
       use julia multithreading (LSQ assembly)
     * WFL_ACE_FIT_BLAS_THREADS: used by ace_fit.jl for number of threads to set for BLAS
       multithreading in ace_fit
-    * WFL_ACE_FIT_COMMAND: command to execute ace_fit.jl, e.g. 
+    * WFL_ACE_FIT_COMMAND: command to execute ace_fit.jl, e.g.
       ``julia $HOME/.julia/packages/ACE1pack/ChRvA/scripts/ace_fit.jl``
 
 
@@ -51,8 +50,8 @@ def fit(fitting_configs, ACE_name, ace_fit_params, ace_fit_command=None,
         Any file names (ACE, fitting configs) already present will be updated.
         See :func:`wfl.fit.ace.prepare_params` for other parameters that will be set automatically.
     ace_fit_command: str, default None
-        executable for ace_fit. 
-        e.g. ``julia $HOME/.julia/packages/ACE1pack/ChRvA/scripts/ace_fit.jl`` or similar. 
+        executable for ace_fit.
+        e.g. ``julia $HOME/.julia/packages/ACE1pack/ChRvA/scripts/ace_fit.jl`` or similar.
         Alternatively set by `WFL_ACE_FIT_COMMAND` env var.
     ref_property_prefix: str, default 'REF\_'
         string prefix added to atoms.info/arrays keys (energy, forces, virial, stress)
@@ -90,7 +89,7 @@ def fit(fitting_configs, ACE_name, ace_fit_params, ace_fit_command=None,
 
     fitting_configs = prepare_configs(fitting_configs, ref_property_prefix)
     ace_fit_params = prepare_params(ACE_name, fitting_configs, ace_fit_params, run_dir, ref_property_prefix,
-                                    isolated_atom_info_key=isolated_atom_info_key, 
+                                    isolated_atom_info_key=isolated_atom_info_key,
                                     isolated_atom_info_value=isolated_atom_info_value)
 
     return run_ace_fit(fitting_configs, ace_fit_params,
@@ -112,7 +111,7 @@ def prepare_params(ACE_name, fitting_configs, ace_fit_params, run_dir='.', ref_p
         set of configurations to fit
     ace_fit_params: dict
         dict with all fitting parameters for ACE1pack,
-        to be updated with 
+        to be updated with
 
         * ``(energy|force|virial)_key`` (with ref_property_prefix)
         * ``ACE_fname``
@@ -142,7 +141,7 @@ def prepare_params(ACE_name, fitting_configs, ace_fit_params, run_dir='.', ref_p
 
     ace_fit_params["data"]["energy_key"] = f"{ref_property_prefix}energy"
     ace_fit_params["data"]["force_key"] = f"{ref_property_prefix}forces"
-    ace_fit_params["data"]["virial_key"] = f"{ref_property_prefix}virial" # TODO is this correct?
+    ace_fit_params["data"]["virial_key"] = f"{ref_property_prefix}virial"  # TODO is this correct?
 
     ace_filename = str(Path(run_dir) / (ACE_name + '.json'))
     if "ACE_fname" in ace_fit_params:
@@ -164,13 +163,13 @@ def prepare_params(ACE_name, fitting_configs, ace_fit_params, run_dir='.', ref_p
                 config_type = f"config_{at_i}"
                 at.info["config_type"] = config_type
                 if from_sigma is True:
-                    ace_fit_params["weights"][config_type] = { "E": default_weights.get("E", 1.0) / at.info.get("energy_sigma", 1.0),
-                                                               "F": default_weights.get("F", 1.0) / at.info.get("force_sigma", 1.0),
-                                                               "V": default_weights.get("V", 1.0) / at.info.get("virial_sigma", 1.0) }
+                    ace_fit_params["weights"][config_type] = {"E": default_weights.get("E", 1.0) / at.info.get("energy_sigma", 1.0),
+                                                              "F": default_weights.get("F", 1.0) / at.info.get("force_sigma", 1.0),
+                                                              "V": default_weights.get("V", 1.0) / at.info.get("virial_sigma", 1.0)}
                 else:
-                    ace_fit_params["weights"][config_type] = { "E": default_weights.get("E", 1.0) / at.info.get(from_sigma, 1.0),
-                                                               "F": default_weights.get("F", 1.0) / at.info.get(from_sigma, 1.0),
-                                                               "V": default_weights.get("V", 1.0) / at.info.get(from_sigma, 1.0) }
+                    ace_fit_params["weights"][config_type] = {"E": default_weights.get("E", 1.0) / at.info.get(from_sigma, 1.0),
+                                                              "F": default_weights.get("F", 1.0) / at.info.get(from_sigma, 1.0),
+                                                              "V": default_weights.get("V", 1.0) / at.info.get(from_sigma, 1.0)}
 
     return ace_fit_params
 
@@ -204,9 +203,9 @@ def run_ace_fit(fitting_configs, ace_fit_params, skip_if_present=False, run_dir=
         skip fitting if output is already present
     run_dir: str or Path, default '.'
         directory to run in
-    ace_fit_command: str, default None. 
-        executable for ace_fit. 
-        e.g. `julia $HOME/.julia/packages/ACE1pack/ChRvA/scripts/ace_fit.jl` or similar. 
+    ace_fit_command: str, default None.
+        executable for ace_fit.
+        e.g. `julia $HOME/.julia/packages/ACE1pack/ChRvA/scripts/ace_fit.jl` or similar.
         Alternatively set by WFL_ACE_FIT_COMMAND.
     dry_run: bool, default False
         do a dry run, which returns the matrix size, rather than the potential file path
@@ -272,9 +271,9 @@ def run_ace_fit(fitting_configs, ace_fit_params, skip_if_present=False, run_dir=
 
         xpr = ExPyRe(name=remote_info.job_name, pre_run_commands=remote_info.pre_cmds, post_run_commands=remote_info.post_cmds,
                       env_vars=remote_info.env_vars, input_files=input_files, output_files=output_files, function=run_ace_fit,
-                      kwargs= {'fitting_configs': fitting_configs, 'ace_fit_params': ace_fit_params,
-                               'run_dir': run_dir, 'ace_fit_command': ace_fit_command,
-                               'dry_run': dry_run, 'verbose': verbose, 'remote_info': '_IGNORE'})
+                      kwargs={'fitting_configs': fitting_configs, 'ace_fit_params': ace_fit_params,
+                              'run_dir': run_dir, 'ace_fit_command': ace_fit_command,
+                              'dry_run': dry_run, 'verbose': verbose, 'remote_info': '_IGNORE'})
 
         xpr.start(resources=remote_info.resources, system_name=remote_info.sys_name, header_extra=remote_info.header_extra,
                   exact_fit=remote_info.exact_fit, partial_node=remote_info.partial_node)
@@ -319,20 +318,18 @@ def run_ace_fit(fitting_configs, ace_fit_params, skip_if_present=False, run_dir=
     if ace_fit_command is None:
         ace_fit_command = ace_fit_jl_path()
 
-    orig_julia_num_threads = (os.environ.get('JULIA_NUM_THREADS', None))
     if 'WFL_ACE_FIT_JULIA_THREADS' in os.environ:
         os.environ['JULIA_NUM_THREADS'] = os.environ['WFL_ACE_FIT_JULIA_THREADS']
-
 
     cmd = f"{ace_fit_command} --params {ace_fit_params_filename} "
     if dry_run:
         cmd += "--dry-run "
 
-    ace_fit_blas_threads= os.environ.get("WFL_ACE_FIT_BLAS_THREADS", None)
+    ace_fit_blas_threads = os.environ.get("WFL_ACE_FIT_BLAS_THREADS", None)
     if ace_fit_blas_threads is not None:
         cmd += f"--num-blas-threads {int(ace_fit_blas_threads)} "
 
-    cmd +=  f"> {ace_file_base}.stdout 2> {ace_file_base}.stderr "
+    cmd += f"> {ace_file_base}.stdout 2> {ace_file_base}.stderr "
 
     if verbose:
         print('fitting command:\n', cmd)

--- a/wfl/fit/ace.py
+++ b/wfl/fit/ace.py
@@ -268,7 +268,7 @@ def run_ace_fit(fitting_configs, ace_fit_params, skip_if_present=False, run_dir=
         input_files = remote_info.input_files.copy()
         # run dir will contain only things created by fitting, so it's safe to copy the
         # entire thing back as output
-        output_files = remote_info + [str(run_dir)]
+        output_files = remote_info.output_files + [str(run_dir)]
 
         xpr = ExPyRe(name=remote_info.job_name, pre_run_commands=remote_info.pre_cmds, post_run_commands=remote_info.post_cmds,
                       env_vars=remote_info.env_vars, input_files=input_files, output_files=output_files, function=run_ace_fit,

--- a/wfl/fit/ace.py
+++ b/wfl/fit/ace.py
@@ -266,11 +266,9 @@ def run_ace_fit(fitting_configs, ace_fit_params, skip_if_present=False, run_dir=
 
     if remote_info is not None and remote_info != '_IGNORE':
         input_files = remote_info.input_files.copy()
-        output_files = remote_info.output_files.copy()
-
         # run dir will contain only things created by fitting, so it's safe to copy the
         # entire thing back as output
-        output_files.append(str(run_dir))
+        output_files = remote_info + [str(run_dir)]
 
         xpr = ExPyRe(name=remote_info.job_name, pre_run_commands=remote_info.pre_cmds, post_run_commands=remote_info.post_cmds,
                       env_vars=remote_info.env_vars, input_files=input_files, output_files=output_files, function=run_ace_fit,

--- a/wfl/fit/error.py
+++ b/wfl/fit/error.py
@@ -1,7 +1,5 @@
 import warnings
-import sys
 import re
-import itertools
 
 import pandas as pd
 import numpy as np
@@ -103,7 +101,7 @@ def calc(inputs, calc_property_prefix, ref_property_prefix,
 
     # compute diffs and store in all_diffs, and weights in all_weights
     all_diffs = {}
-    all_parity = { "ref": {}, "calc": {} }
+    all_parity = {"ref": {}, "calc": {}}
     all_weights = {}
 
     missed_prop_counter = {}
@@ -135,7 +133,7 @@ def calc(inputs, calc_property_prefix, ref_property_prefix,
                 if by_species:
                     raise ValueError("/Z only possible in atom_properties")
                 data = at.info
-            else: # atom_properties
+            else:  # atom_properties
                 if per_atom:
                     raise ValueError("/atom only possible in config_properties")
                 data = at.arrays
@@ -166,7 +164,7 @@ def calc(inputs, calc_property_prefix, ref_property_prefix,
                 # things by Z will lump them all together.
                 atom_split_indices = np.asarray(range(len(ref_quant)))
                 atom_split_groups = [(atom_split_indices, "")]
-            else: # atom_properties
+            else:  # atom_properties
                 # Make separate groups for each atomic number Z, so their errors
                 # can be tabulated separately.
                 Zs = at.numbers
@@ -197,14 +195,14 @@ def calc(inputs, calc_property_prefix, ref_property_prefix,
                     selected_calc_quant = np.linalg.norm(selected_calc_quant, axis=1)
 
 
-                _dict_add([all_diffs, all_weights,            all_parity["ref"],   all_parity["calc"]],
-                          [diff,      _promote(weight, diff), selected_ref_quant,           selected_calc_quant        ],
+                _dict_add([all_diffs, all_weights,            all_parity["ref"],  all_parity["calc"]],
+                          [diff,      _promote(weight, diff), selected_ref_quant, selected_calc_quant],
                           at_category, prop + atom_split_index_label)
 
     if len(missed_prop_counter.keys()) > 0:
         for missed_prop, count in missed_prop_counter.items():
             if count == len(list(inputs)):
-                raise RuntimeError(f"Missing reference ({ref_property_prefix}) or calculated ({calc_property_prefix}) "\
+                raise RuntimeError(f"Missing reference ({ref_property_prefix}) or calculated ({calc_property_prefix}) "
                                     f"property '{missed_prop}' in all of the configs. Is the spelling correct? ")
             else:
                 warnings.warn(f"Missing reference or calculated property '{missed_prop}', {count} times")
@@ -221,7 +219,7 @@ def calc(inputs, calc_property_prefix, ref_property_prefix,
             MAE = np.sum(np.abs(diffs) * weights) / np.sum(weights)
             num = len(diffs)
 
-            all_errors[prop][cat] = {'RMSE': RMSE, 'MAE': MAE, 'count' : num}
+            all_errors[prop][cat] = {'RMSE': RMSE, 'MAE': MAE, 'count': num}
 
     # if len(all_diffs) == 0:
     #     raise RuntimeError(f"No values were found to calculate error from."\
@@ -257,15 +255,15 @@ def value_error_scatter(all_errors, all_diffs, all_parity, output, properties=No
     cmap: str, default None
         colormap name to use. If None use default based on number of categories.
     units_dict: dict, default None
-        dictionary with units for non-default properties. Example: 
+        dictionary with units for non-default properties. Example:
         {"energy": {"parity": ("eV", 1.0), "error": ("meV", 1.0e3)}},
-        Where each tuple containes units lable and conversion factor from ASE-default units.  
+        Where each tuple containes units lable and conversion factor from ASE-default units.
     """
 
     assert error_type in ["RMSE", "MAE"], f"'error_type' must be 'RMSE' or 'MAE', not {error_type}."
 
-    num_rows = sum([plot_parity, plot_error])   # one for parity, one for errors
-    num_columns = len(all_errors.keys()) # one column per property
+    num_rows = sum([plot_parity, plot_error])  # one for parity, one for errors
+    num_columns = len(all_errors.keys())  # one column per property
     side = 4.5
     fig = Figure(figsize=(side * num_columns, side * num_rows))
     gs = fig.add_gridspec(num_rows, num_columns, wspace=0.25, hspace=0.25)
@@ -360,16 +358,16 @@ def select_units(prop, plt_type, units_dict=None):
 
     Parameters
     ----------
-    prop: str 
-        name of property. By default upported "energy", "atomization_energy", "forces" and "virial", 
+    prop: str
+        name of property. By default upported "energy", "atomization_energy", "forces" and "virial",
         in combination with "/atom", "/comp", "/Z" as appropriate.
     plt_type: str in ["error", "parity"]
         type of plot
-    units_dict: dict, default None 
-        dictionary with units for non-default properties. Example: 
+    units_dict: dict, default None
+        dictionary with units for non-default properties. Example:
         {"energy": {"parity": ("eV", 1.0), "error": ("meV", 1.0e3)}},
-        Where each tuple containes units lable and conversion factor from ASE-default units. 
- 
+        Where each tuple containes units lable and conversion factor from ASE-default units.
+
 
     Returns
     -------
@@ -399,7 +397,7 @@ def select_units(prop, plt_type, units_dict=None):
         prop = re.sub(r"atomization_energy", "energy", prop)
 
     if prop not in use_units_dict or plt_type not in use_units_dict[prop]:
-        raise KeyError(f"Unknown property ({prop}) or plot type ({plt_type}).") 
+        raise KeyError(f"Unknown property ({prop}) or plot type ({plt_type}).")
 
     return use_units_dict[prop][plt_type]
 
@@ -413,7 +411,7 @@ def _annotate_parity_plot(ax, property, ref_property_prefix, calc_property_prefi
 
     xmin, xmax = ax.get_xlim()
     ymin, ymax = ax.get_ylim()
-    lims = (min([xmin, ymin])-0.1, max([xmax, ymax])+0.1)
+    lims = (min([xmin, ymin]) - 0.1, max([xmax, ymax]) + 0.1)
     ax.set_xlim(lims)
     ax.set_ylim(lims)
     ax.plot(lims, lims, c='k', linewidth=0.8)
@@ -444,10 +442,10 @@ def errors_dumps(errors, error_type="RMSE", precision=2):
 
     df = errors_to_dataframe(errors, error_type=error_type)
     df_str = df.to_string(
-        max_rows = None,
-        max_cols = None,
-        float_format = "{{:.{:d}f}}".format(precision).format,
-        sparsify = False
+        max_rows=None,
+        max_cols=None,
+        float_format="{{:.{:d}f}}".format(precision).format,
+        sparsify=False
     )
     return df_str
 
@@ -463,9 +461,9 @@ def errors_to_dataframe(errors, error_type="RMSE", units_dict=None):
     error_type: str in ["RMSE, "MAE"], default "RMSE"
         root-mean-square or maximum-absolute error
     units_dict: dict, None
-        dictionary with units for non-default properties. Example: 
+        dictionary with units for non-default properties. Example:
         {"energy": {"parity": ("eV", 1.0), "error": ("meV", 1.0e3)}},
-        Where each tuple containes units lable and conversion factor from ASE-default units. 
+        Where each tuple containes units lable and conversion factor from ASE-default units.
     """
     # errors keys
     # property : category : RMSE/MAE/count
@@ -503,7 +501,7 @@ def errors_to_dataframe(errors, error_type="RMSE", units_dict=None):
     df = pd.DataFrame.from_dict(df_errors)
 
     # sort rows alphabetically
-    new_rows =  [row for row in df.index if row != "_ALL_"]
+    new_rows = [row for row in df.index if row != "_ALL_"]
     new_rows = natural_sort(new_rows) + ["_ALL_"]
 
     df.sort_index(key=lambda index: pd.Index([new_rows.index(i) for i in index]), inplace=True)
@@ -511,6 +509,8 @@ def errors_to_dataframe(errors, error_type="RMSE", units_dict=None):
     return df
 
 def natural_sort(l):
-    convert = lambda text: int(text) if text.isdigit() else text.lower()
-    alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
+    def convert(text):
+        return int(text) if text.isdigit() else text.lower()
+    def alphanum_key(key):
+        return [convert(c) for c in re.split('([0-9]+)', key)]
     return sorted(l, key=alphanum_key)

--- a/wfl/fit/gap/__init__.py
+++ b/wfl/fit/gap/__init__.py
@@ -1,1 +1,3 @@
 from . import multistage, simple, glue_2b
+
+__all__ = ["multistage", "simple", "glue_2b"]

--- a/wfl/fit/gap/glue_2b.py
+++ b/wfl/fit/gap/glue_2b.py
@@ -6,7 +6,6 @@ import ase
 import ase.data
 import numpy as np
 
-from wfl.configset import ConfigSet
 from wfl.utils.vol_composition_space import composition_space_Zs
 
 

--- a/wfl/fit/gap/multistage.py
+++ b/wfl/fit/gap/multistage.py
@@ -4,8 +4,6 @@ from copy import deepcopy
 from pathlib import Path
 from xml.etree import cElementTree
 
-from pathlib import Path
-
 import ase.io
 import numpy as np
 import yaml
@@ -195,8 +193,9 @@ def fit(fitting_configs, GAP_name, params, ref_property_prefix='REF_',
 
         xpr = ExPyRe(name=remote_info.job_name, pre_run_commands=remote_info.pre_cmds, post_run_commands=remote_info.post_cmds,
                      env_vars=remote_info.env_vars, input_files=input_files, output_files=output_files, function=fit,
-                     kwargs={'fitting_configs': fitting_configs, 'GAP_name': GAP_name, 'params': params, 'ref_property_prefix': ref_property_prefix,
-                             'seeds': seeds, 'skip_if_present': skip_if_present, 'run_dir': run_dir, 
+                     kwargs={'fitting_configs': fitting_configs, 'GAP_name': GAP_name, 'params': params,
+                             'ref_property_prefix': ref_property_prefix,
+                             'seeds': seeds, 'skip_if_present': skip_if_present, 'run_dir': run_dir,
                              'num_committee': num_committee, 'committee_extra_seeds': committee_extra_seeds,
                              'committee_name_postfix': committee_name_postfix, 'verbose': verbose, 'remote_info': '_IGNORE'})
 
@@ -433,7 +432,7 @@ def fit(fitting_configs, GAP_name, params, ref_property_prefix='REF_',
 
         # do a simple fit using gap_simple_fit
         stdout_file = run_dir / f'stdout.{GAP_name}.stage_{i_stage}.gap_fit'
-        # If this function was called without a remote_info that applies to it, remote_info here 
+        # If this function was called without a remote_info that applies to it, remote_info here
         # will still be the real remote_info, which can then be used in the underlying simple fits
         # If we're here with the multistage fit running remotely, the wrapper above passed
         # _IGNORE as remote_info, so these fits will run in this job, not their own separate remote

--- a/wfl/fit/gap/relocate.py
+++ b/wfl/fit/gap/relocate.py
@@ -62,7 +62,7 @@ def gap_relocate(old_file, new_file, extra_filename_glob=None, delete_old=False)
                 cleanup_files.append(Path(old_file).parent / extra_file.name)
                 sys.stderr.write(f'copying extra {cleanup_files[-1]} '
                                  f'{Path(new_file).parent / extra_file.name.replace(old_file.name, new_file.name, 1)}\n')
-                shutil.copyfile(cleanup_files[-1],  Path(new_file).parent / extra_file.name.replace(old_file.name, new_file.name, 1))
+                shutil.copyfile(cleanup_files[-1], Path(new_file).parent / extra_file.name.replace(old_file.name, new_file.name, 1))
 
     et.write(new_file)
     cleanup_files.append(old_file)
@@ -93,6 +93,5 @@ def _filename_rename(root, old_name, new_name):
 
 
 if __name__ == '__main__':
-    import sys
     assert len(sys.argv) == 3 or len(sys.argv) == 4
     gap_relocate(*sys.argv[1:])

--- a/wfl/fit/gap/simple.py
+++ b/wfl/fit/gap/simple.py
@@ -18,7 +18,7 @@ from expyre import ExPyRe
 
 def run_gap_fit(fitting_configs, fitting_dict, stdout_file, gap_fit_command=None,
                 verbose=True, do_fit=True, remote_info=None, remote_label=None,
-                skip_if_present=False,  **kwargs):
+                skip_if_present=False, **kwargs):
     """Runs gap_fit
 
     Parameters
@@ -31,8 +31,8 @@ def run_gap_fit(fitting_configs, fitting_dict, stdout_file, gap_fit_command=None
         filename to pass standard output to
     gap_fit_command: str, default "gap_fit"
         executable for gap_fit.
-        Alternatively set by WFL_GAP_FIT_COMMAND environment variable, 
-        which overrides this `gap_fit_command` argument. 
+        Alternatively set by WFL_GAP_FIT_COMMAND environment variable,
+        which overrides this `gap_fit_command` argument.
     verbose: bool, default True
     do_fit: bool, default True
         carry out the fit, otherwise only print fitting command
@@ -141,14 +141,14 @@ def run_gap_fit(fitting_configs, fitting_dict, stdout_file, gap_fit_command=None
         fitting_configs_scratch_filename = filename
         # use in actual fit
         fitting_configs_filename = fitting_configs_scratch_filename
-    
+
     # kwargs overwrite the fitting_dict given
     use_fitting_dict = dict(fitting_dict, atoms_filename=fitting_configs_filename, **kwargs)
 
     fitting_line = dict_to_gap_fit_string(use_fitting_dict)
 
     if gap_fit_command is None:
-        gap_fit_command = os.environ.get("WFL_GAP_FIT_COMMAND", None)        
+        gap_fit_command = os.environ.get("WFL_GAP_FIT_COMMAND", None)
         if gap_fit_command is None:
             gap_fit_command = "gap_fit"
 
@@ -222,7 +222,7 @@ def dict_to_gap_fit_string(param_dict):
 
 def _Path_to_str(param_dict):
 
-    possible_file_keys = ["atoms_filename", "at_file", "baseline_param_filename", 
+    possible_file_keys = ["atoms_filename", "at_file", "baseline_param_filename",
                           "core_param_file", "gap_file", "gp_file", "template_file"]
 
     for key in possible_file_keys:

--- a/wfl/fit/gap/simple.py
+++ b/wfl/fit/gap/simple.py
@@ -133,7 +133,7 @@ def run_gap_fit(fitting_configs, fitting_dict, stdout_file, gap_fit_command=None
     fitting_configs_filename = fitting_configs.one_file()
     if not fitting_configs_filename:
         # not one file, must write scratch file with all configs
-        fd_scratch, filename = tempfile.mkstemp(prefix="_GAP_fitting_configs.", suffix=".xyz")
+        fd_scratch, filename = tempfile.mkstemp(prefix="_GAP_fitting_configs.", suffix=".xyz", dir=".")
         os.close(fd_scratch)
 
         ase.io.write(filename, fitting_configs)

--- a/wfl/fit/utils.py
+++ b/wfl/fit/utils.py
@@ -1,7 +1,5 @@
 import os
-import json
 import numpy as np
-import os
 import subprocess
 from pathlib import Path
 import shlex
@@ -9,7 +7,6 @@ import warnings
 
 from ase.constraints import voigt_6_to_full_3x3_stress
 
-from wfl.autoparallelize import RemoteInfo
 from wfl.utils.julia import julia_exec_path
 
 
@@ -112,11 +109,11 @@ def copy_properties(configs, ref_property_keys, stress_to_virial=True, force=Tru
                         raise RuntimeError(f'at.info key CALC_{result_key} already exists)')
                     at.info[f'CALC_{result_key}'] = at.calc.results[result_key]
             if 'forces' in at.calc.results:
-                if f'CALC_forces' in at.arrays:
+                if 'CALC_forces' in at.arrays:
                     if force:
                         del at.arrays['CALC_forces']
                     else:
-                        raise RuntimeError(f'at.arrays key CALC_forces already exists')
+                        raise RuntimeError('at.arrays key CALC_forces already exists')
                 at.new_array('CALC_forces', at.calc.results['forces'])
             if 'CALC_hessian' in at.arrays:
                 # no Hessian (in the format we need) from calculator, remove any old ones

--- a/wfl/generate/atoms_and_dimers.py
+++ b/wfl/generate/atoms_and_dimers.py
@@ -2,8 +2,6 @@ import numpy as np
 from ase import data
 from ase.atoms import Atoms
 
-from wfl.configset import ConfigSet
-
 
 def prepare(outputs, atomic_numbers, bond_lengths=None, dimer_n_steps=41, dimer_factor_range=(0.65, 2.5),
             dimer_box_scale=6.0, extra_info=None, do_isolated_atoms=True, max_cutoff=None, fixed_cell=False):

--- a/wfl/generate/md/__init__.py
+++ b/wfl/generate/md/__init__.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import numpy as np
@@ -35,8 +34,8 @@ def _sample_autopara_wrappable(atoms, calculator, steps, dt, integrator="NVTBere
         ASE calculator or routine to call to create calculator
     dt: float
         time step (fs)
-	integrator: str, default "NVTBerendsen"
-		Select integrator. Default is Berendsen but also langevin can be used
+    integrator: str, default "NVTBerendsen"
+        Select integrator. Default is Berendsen but also langevin can be used
     steps: int
         number of steps
     temperature: float or (float, float, [int]]), or list of dicts  default None
@@ -81,7 +80,7 @@ def _sample_autopara_wrappable(atoms, calculator, steps, dt, integrator="NVTBere
     -------
         list(Atoms) trajectories
     """
-    assert integrator in ["NVTBerendsen", "Langevin"] 
+    assert integrator in ["NVTBerendsen", "Langevin"]
 
     calculator = construct_calculator_picklesafe(calculator)
 
@@ -103,7 +102,7 @@ def _sample_autopara_wrappable(atoms, calculator, steps, dt, integrator="NVTBere
             # create a stage dict from a constant or ramp
             t_stage_data = temperature
             # start with constant
-            t_stage = { 'T_i': t_stage_data[0], 'T_f' : t_stage_data[0], 'traj_frac': 1.0, 'n_stages': 10, 'steps': steps }
+            t_stage = {'T_i': t_stage_data[0], 'T_f': t_stage_data[0], 'traj_frac': 1.0, 'n_stages': 10, 'steps': steps}
             if len(t_stage_data) >= 2:
                 # set different final T for ramp
                 t_stage['T_f'] = t_stage_data[1]
@@ -115,7 +114,7 @@ def _sample_autopara_wrappable(atoms, calculator, steps, dt, integrator="NVTBere
             for t_stage in temperature:
                 if 'n_stages' not in t_stage:
                     t_stage['n_stages'] = 10
-    
+
     for at_i, at in enumerate(atoms_to_list(atoms)):
         if autopara_per_item_info is not None:
             np.random.seed(autopara_per_item_info[at_i]["rng_seed"])
@@ -152,7 +151,7 @@ def _sample_autopara_wrappable(atoms, calculator, steps, dt, integrator="NVTBere
             md_constructor = VelocityVerlet
             # one stage, simple
             all_stage_kwargs = [stage_kwargs.copy()]
-            all_run_kwargs = [ {'steps': steps} ]
+            all_run_kwargs = [{'steps': steps}]
 
         else:
             # NVT or NPT

--- a/wfl/generate/md/abort.py
+++ b/wfl/generate/md/abort.py
@@ -20,7 +20,7 @@ class AbortOnCollision(AbortSimBase):
     """
 
     def __init__(self, collision_radius, n_failed_steps=3):
-        super().__init__(n_failed_steps)        
+        super().__init__(n_failed_steps)
         self.collision_radius = collision_radius
 
 

--- a/wfl/generate/minimahopping.py
+++ b/wfl/generate/minimahopping.py
@@ -17,7 +17,7 @@ from wfl.utils.parallel import construct_calculator_picklesafe
 
 
 def _get_MD_trajectory(rundir):
-    
+
     md_traj = []
     mdtrajfiles = sorted([file for file in Path(rundir).glob("md*.traj")])
     for mdtraj in mdtrajfiles:

--- a/wfl/generate/normal_modes.py
+++ b/wfl/generate/normal_modes.py
@@ -351,12 +351,10 @@ class NormalModes:
             energy = sum([aa ** 2 * eigenval / 2 for aa, eigenval in
                           zip(alphas, self.eigenvalues[normal_mode_numbers])])
 
-            displaced_at.info[f'{self.prop_prefix}normal_mode_energy'] \
-                = energy
+            displaced_at.info[f'{self.prop_prefix}normal_mode_energy'] = energy
 
             if temp is not None:
-                displaced_at.info[f'{self.prop_prefix}normal_mode_temperature'] \
-                = temp
+                displaced_at.info[f'{self.prop_prefix}normal_mode_temperature'] = temp
 
             sampled_configs.append(displaced_at)
         return sampled_configs
@@ -386,9 +384,9 @@ class NormalModes:
             generic.calculate(
                 inputs=displaced_in_configset,
                 outputs=displaced_out_configset,
-                calculator=calculator, 
+                calculator=calculator,
                 output_prefix=self.prop_prefix,
-                properties=properties, 
+                properties=properties,
                 autopara_info=AutoparaInfo(num_inputs_per_python_subprocess=1))
 
             self._write_nm_to_atoms(
@@ -573,10 +571,11 @@ def _generate_normal_modes_autopara_wrappable(inputs, calculator, prop_prefix,
 
 
 def generate_normal_modes_parallel_atoms(*args, **kwargs):
-     # iterable loop parallelizes over input structures, not over 6xN
+    # iterable loop parallelizes over input structures, not over 6xN
     # displaced structures needed for numerical hessian
-    kwargs["parallel_hessian"] = False 
-    return autoparallelize(_generate_normal_modes_autopara_wrappable, *args, default_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+    kwargs["parallel_hessian"] = False
+    return autoparallelize(_generate_normal_modes_autopara_wrappable, *args,
+                           default_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
 autoparallelize_docstring(generate_normal_modes_parallel_atoms, _generate_normal_modes_autopara_wrappable, "Atoms")
 
 

--- a/wfl/generate/optimize.py
+++ b/wfl/generate/optimize.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import ase.units
@@ -37,7 +36,7 @@ def _run_autopara_wrappable(atoms, calculator, fmax=1.0e-3, smax=None, steps=100
            results_prefix='optimize_', verbose=False, update_config_type=True,
            autopara_rng_seed=None, autopara_per_item_info=None,
            **opt_kwargs):
-    """runs a structure optimization 
+    """runs a structure optimization
 
     Parameters
     ----------
@@ -115,7 +114,7 @@ def _run_autopara_wrappable(atoms, calculator, fmax=1.0e-3, smax=None, steps=100
         at.calc = calculator
         if pressure is not None:
             p = sample_pressure(pressure, at)
-            at.info[f'optimize_pressure_GPa'] = p
+            at.info['optimize_pressure_GPa'] = p
             p *= ase.units.GPa
             wrapped_at = ExpCellFilter(at, scalar_pressure=p)
         else:
@@ -203,9 +202,9 @@ def _run_autopara_wrappable(atoms, calculator, fmax=1.0e-3, smax=None, steps=100
 
 
 def optimize(*args, **kwargs):
-    default_autopara_info={"num_inputs_per_python_subprocess":10}
+    default_autopara_info = {"num_inputs_per_python_subprocess": 10}
 
-    return autoparallelize(_run_autopara_wrappable, *args, 
+    return autoparallelize(_run_autopara_wrappable, *args,
                            default_autopara_info=default_autopara_info, **kwargs)
 autoparallelize_docstring(optimize, _run_autopara_wrappable, "Atoms")
 

--- a/wfl/generate/phonopy.py
+++ b/wfl/generate/phonopy.py
@@ -50,7 +50,7 @@ def _run_autopara_wrappable(atoms, displacements, strain_displs, ph2_supercell, 
             assert sc.shape == (3,)
             sc_mat = np.diag(sc)
         else:
-            assert sc.shape == (3,3)
+            assert sc.shape == (3, 3)
             sc_mat = sc
 
         return sc_mat
@@ -78,15 +78,15 @@ def _run_autopara_wrappable(atoms, displacements, strain_displs, ph2_supercell, 
 
                 if displ_i == 0:
                     # store undisplaced phonon (harmonic) config
-                    at_pert = Atoms(cell=d2_undispl.cell, positions=d2_undispl.positions, numbers=d2_undispl.numbers, pbc=[True]*3)
+                    at_pert = Atoms(cell=d2_undispl.cell, positions=d2_undispl.positions, numbers=d2_undispl.numbers, pbc=[True] * 3)
                     if ph3_sc_mat is not None and np.any(ph2_sc_mat != ph3_sc_mat):
                         # fc2 and fc3 are different supercells, need different undisplaced configs
-                        at_pert.info["config_type"] = f"phonon_harmonic_undispl"
+                        at_pert.info["config_type"] = "phonon_harmonic_undispl"
                     else:
-                        at_pert.info["config_type"] = f"phonon_undispl"
+                        at_pert.info["config_type"] = "phonon_undispl"
                     ats_pert[-1].append(at_pert)
                 for at in d2:
-                    at_pert = Atoms(cell=at.cell, positions=at.positions, numbers=at.numbers, pbc=[True]*3)
+                    at_pert = Atoms(cell=at.cell, positions=at.positions, numbers=at.numbers, pbc=[True] * 3)
                     at_pert.info["config_type"] = f"phonon_harmonic_{displ_i}"
                     ats_pert[-1].append(at_pert)
 
@@ -98,22 +98,22 @@ def _run_autopara_wrappable(atoms, displacements, strain_displs, ph2_supercell, 
 
                 if displ_i == 0 and (ph2_sc_mat is None or np.any(ph2_sc_mat != ph3_sc_mat)):
                     # store undisplaced fc3 (cubic) config
-                    at_pert = Atoms(cell=d3_undispl.cell, positions=d3_undispl.positions, numbers=d3_undispl.numbers, pbc=[True]*3)
+                    at_pert = Atoms(cell=d3_undispl.cell, positions=d3_undispl.positions, numbers=d3_undispl.numbers, pbc=[True] * 3)
                     if ph2_sc_mat is not None and np.any(ph2_sc_mat != ph3_sc_mat):
-                        at_pert.info["config_type"] = f"phonon_cubic_undispl"
+                        at_pert.info["config_type"] = "phonon_cubic_undispl"
                     else:
-                        at_pert.info["config_type"] = f"phonon_undispl"
+                        at_pert.info["config_type"] = "phonon_undispl"
                     ats_pert[-1].append(at_pert)
                 for at in d3:
-                    at_pert = Atoms(cell=at.cell, positions=at.positions, numbers=at.numbers, pbc=[True]*3)
+                    at_pert = Atoms(cell=at.cell, positions=at.positions, numbers=at.numbers, pbc=[True] * 3)
                     at_pert.info["config_type"] = f"phonon_cubic_{displ_i}"
                     ats_pert[-1].append(at_pert)
 
         for displ_i, displ in enumerate(strain_displs):
             for i0 in range(3):
-                for i1 in range(i0+1):
+                for i1 in range(i0 + 1):
                     F = np.eye(3)
-                    F[i0,i1] += displ
+                    F[i0, i1] += displ
                     at_pert = at0.copy()
                     at_pert.set_cell(at_pert.cell @ F, scale_atoms=True)
                     at_pert.info["config_type"] = f"phonon_strain_{displ_i}"
@@ -123,5 +123,5 @@ def _run_autopara_wrappable(atoms, displacements, strain_displs, ph2_supercell, 
 
 
 def phonopy(*args, **kwargs):
-    return autoparallelize(_run_autopara_wrappable, *args, default_autopara_info={"num_inputs_per_python_subprocess":10}, **kwargs)
+    return autoparallelize(_run_autopara_wrappable, *args, default_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
 autoparallelize_docstring(phonopy, _run_autopara_wrappable, "Atoms")

--- a/wfl/generate/supercells.py
+++ b/wfl/generate/supercells.py
@@ -105,7 +105,7 @@ def _largest_bulk_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=Tru
         at.info['orig_cell'] = np.array(at.cell)
 
         if ase_optimal:
-            n_dups = ase.build.supercells.find_optimal_cell_shape(at.cell, max_n_atoms // len(at), 'sc') # , lower_limit=-4, upper_limit=4)
+            n_dups = ase.build.supercells.find_optimal_cell_shape(at.cell, max_n_atoms // len(at), 'sc')  # , lower_limit=-4, upper_limit=4)
             sc = ase.build.make_supercell(at, n_dups)
             sc.info.update(at.info)
             at = sc
@@ -131,7 +131,8 @@ def _largest_bulk_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=Tru
 
 
 def largest_bulk(*args, **kwargs):
-    return autoparallelize(_largest_bulk_autopara_wrappable, *args, default_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+    return autoparallelize(_largest_bulk_autopara_wrappable, *args,
+                           default_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
 autoparallelize_docstring(largest_bulk, _largest_bulk_autopara_wrappable, "Atoms")
 
 
@@ -176,7 +177,7 @@ def _vacancy_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, sy
                 inds = list(range(len(at)))
                 dists = at.get_distances(init_vac_i, inds, mic=True)
                 nearest_d = np.amin(dists[np.where(dists > 0.0)])
-                nns = np.where(np.logical_and(dists <= cluster_r*nearest_d, dists > 0.0))[0]
+                nns = np.where(np.logical_and(dists <= cluster_r * nearest_d, dists > 0.0))[0]
                 if len(nns) >= n_vac:
                     break
                 n_try += 1
@@ -186,7 +187,7 @@ def _vacancy_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, sy
                 warnings.warn(f'Failed to find vacancy with at least {n_vac}-1 neighbors after 20 tries')
                 continue
 
-            vac_i = np.concatenate(([init_vac_i], np.random.choice(nns, size=n_vac-1, replace=False)))
+            vac_i = np.concatenate(([init_vac_i], np.random.choice(nns, size=n_vac - 1, replace=False)))
         else:
             # entirely random set
             vac_i = np.random.choice(len(at), size=n_vac, replace=False)
@@ -235,7 +236,8 @@ def _antisite_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, s
         if > 0.0, multiply by 1st nn distance of initial antisite, and make antisites in cluster of
         atoms within this distance of initial antisite.
     Zs: iterable(int), default None
-        list of atomic numbers to be used to create antisites.  If none or length 0, use set of species already present in each config for itself.
+        list of atomic numbers to be used to create antisites.  If none or length 0, use set of species already present
+        in each config for itself.
 
     Returns
     -------
@@ -266,7 +268,7 @@ def _antisite_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, s
                 inds = list(range(len(at)))
                 dists = at.get_distances(init_antisite_i, inds, mic=True)
                 nearest_d = np.amin(dists[np.where(dists > 0.0)])
-                nns = np.where(np.logical_and(dists <= cluster_r*nearest_d, dists > 0.0))[0]
+                nns = np.where(np.logical_and(dists <= cluster_r * nearest_d, dists > 0.0))[0]
                 if len(nns) >= n_antisite:
                     break
                 n_try += 1
@@ -276,7 +278,7 @@ def _antisite_autopara_wrappable(atoms, max_n_atoms, pert=0.0, primitive=True, s
                 warnings.warn(f'Failed to find antisite with at least {n_antisite}-1 neighbors after 20 tries')
                 continue
 
-            antisite_i = np.concatenate(([init_antisite_i], np.random.choice(nns, size=n_antisite-1, replace=False)))
+            antisite_i = np.concatenate(([init_antisite_i], np.random.choice(nns, size=n_antisite - 1, replace=False)))
         else:
             # entirely random set
             antisite_i = np.random.choice(len(at), size=n_antisite, replace=False)
@@ -354,7 +356,8 @@ def _interstitial_autopara_wrappable(atoms, max_n_atoms, pert=0.0, interstitial_
 
 
 def interstitial(*args, **kwargs):
-    return autoparallelize(_interstitial_autopara_wrappable, *args, default_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
+    return autoparallelize(_interstitial_autopara_wrappable, *args,
+                           default_autopara_info={"num_inputs_per_python_subprocess": 10}, **kwargs)
 autoparallelize_docstring(interstitial, _interstitial_autopara_wrappable, "Atoms")
 
 

--- a/wfl/select/by_descriptor.py
+++ b/wfl/select/by_descriptor.py
@@ -3,8 +3,6 @@ import warnings
 import numpy as np
 from scipy.sparse.linalg import LinearOperator, svds
 
-from wfl.configset import ConfigSet
-
 
 def do_svd(at_descs, num, do_vectors='vh'):
     def mv(v):
@@ -26,7 +24,7 @@ def _hashable_struct_data(at):
 
 def CUR(mat, num, stochastic=True, stochastic_seed=None, exclude_list=None):
     """Compute selection by CUR of descriptors with dot-product, with optional exponentiation
-    
+
     Parameters
     ----------
     mat: np.array(vec_len, n_vecs) or (n_vecs, n_vecs)

--- a/wfl/select/convex_hull.py
+++ b/wfl/select/convex_hull.py
@@ -1,6 +1,5 @@
 import sys
 
-from wfl.configset import ConfigSet
 from wfl.select.selection_space import composition_space_Zs, composition_space_coord
 from wfl.utils.convex_hull import find_hull
 

--- a/wfl/select/flat_histogram.py
+++ b/wfl/select/flat_histogram.py
@@ -2,8 +2,6 @@ import sys
 
 import numpy as np
 
-from wfl.configset import ConfigSet
-
 
 def _select_by_bin(weights, bin_edges, quantities, n, kT, replace=False, verbose=False):
     if verbose:
@@ -35,7 +33,7 @@ def _select_by_bin(weights, bin_edges, quantities, n, kT, replace=False, verbose
             prefactor_h *= 2
     # binary search for optimal prefactor
     while prefactor_h - prefactor_l > 1.0e-10 * prefactor_h:
-        prefactor_m = (prefactor_l + prefactor_h)/2.0
+        prefactor_m = (prefactor_l + prefactor_h) / 2.0
         n_from_bin = [min(int(w), int(np.round(prefactor_m * np.exp(-bin_ctr / kT)))) for bin_ctr, w in
                       zip(bin_centers, weights)]
         total_n = sum(n_from_bin)

--- a/wfl/select/selection_space.py
+++ b/wfl/select/selection_space.py
@@ -2,7 +2,6 @@ import sys
 
 import numpy as np
 
-from wfl.configset import ConfigSet
 from wfl.utils.vol_composition_space import composition_space_Zs, composition_space_coord
 
 

--- a/wfl/select/simple.py
+++ b/wfl/select/simple.py
@@ -2,9 +2,7 @@ import sys
 from types import LambdaType
 
 import numpy as np
-from ase import Atoms
 
-from wfl.configset import ConfigSet
 from wfl.autoparallelize import autoparallelize, autoparallelize_docstring
 
 
@@ -36,7 +34,7 @@ def by_bool_func(*args, **kwargs):
         num_python_subprocesses = 0
     else:
         num_python_subprocesses = None
-    default_autopara_info={"num_python_subprocesses": num_python_subprocesses}
+    default_autopara_info = {"num_python_subprocesses": num_python_subprocesses}
     return autoparallelize(_select_autopara_wrappable, *args,
            default_autopara_info=default_autopara_info, **kwargs)
 autoparallelize_docstring(by_bool_func, _select_autopara_wrappable, "Atoms")
@@ -68,7 +66,7 @@ def by_index(inputs, outputs, indices):
     multiple outputs for a single input, this cannot be done right now
     """
     if outputs.all_written():
-        sys.stderr.write(f'Returning before by_index since output is done\n')
+        sys.stderr.write('Returning before by_index since output is done\n')
         return outputs.to_ConfigSet()
 
     if len(indices) == 0:

--- a/wfl/utils/configs.py
+++ b/wfl/utils/configs.py
@@ -1,19 +1,18 @@
 from collections import Counter
-import numpy as np
 import warnings
-from wfl.configset import ConfigSet, OutputSpec
+from wfl.configset import OutputSpec
 import wfl.map
 
 
-def find_isolated_atoms(inputs, outputs, isolated_atom_info_key="config_type", 
+def find_isolated_atoms(inputs, outputs, isolated_atom_info_key="config_type",
     isolated_atom_info_value="default"):
-    """Finds isolated atoms in among all configs. 
-    
+    """Finds isolated atoms in among all configs.
+
     Parameters
     ----------
     inputs: list[Atoms] or ConfigSet
         all configs to search through
-    outputs: OutputSpec 
+    outputs: OutputSpec
         where to save isolated atoms to
     isolated_atom_info_key: str, default "config_type"
         key for Atoms.info to select isolated atoms by
@@ -35,10 +34,10 @@ def find_isolated_atoms(inputs, outputs, isolated_atom_info_key="config_type",
     for at in inputs:
         if isolated_atom_info_key in at.info and at.info[isolated_atom_info_key] in isolated_atom_info_value:
             if len(at) != 1:
-                raise RuntimeError(f'Config marked as an isolated atom, but has more than one atom in `Atoms`.')
+                raise RuntimeError('Config marked as an isolated atom, but has more than one atom in `Atoms`.')
             isolated_atoms.append(at)
 
-    found_symbols = [str(at.symbols) for at in isolated_atoms] 
+    found_symbols = [str(at.symbols) for at in isolated_atoms]
     for symbol, count in Counter(found_symbols).items():
         if count != 1:
             raise RuntimeError(f"Isolated atom for element {symbol} found more than once ({count} times).")
@@ -51,28 +50,29 @@ def find_isolated_atoms(inputs, outputs, isolated_atom_info_key="config_type",
 def _get_single_ae(at, prop_prefix, isolated_at_data, ref_present_elements, prop="energy"):
     counted_ats = Counter(list(at.symbols))
     counted_elements = set(counted_ats.keys())
-    assert counted_elements.issubset(ref_present_elements), f"have isolated atom energies for {isolated_at_data.keys()}, but config has {counted_ats.keys()} elements."
+    assert counted_elements.issubset(ref_present_elements), (f"have isolated atom energies for {isolated_at_data.keys()}, but "
+                                                             f"config has {counted_ats.keys()} elements.")
     binding_energy = at.info[f'{prop_prefix}{prop}']
     for symbol, count in counted_ats.items():
         binding_energy -= count * isolated_at_data[symbol]
 
-    at.info[f"{prop_prefix}atomization_{prop}"] = -1 * binding_energy 
+    at.info[f"{prop_prefix}atomization_{prop}"] = -1 * binding_energy
     return at
 
 
-def atomization_energy(inputs, outputs, prop_prefix, prop="energy", isolated_atom_info_key="config_type", 
+def atomization_energy(inputs, outputs, prop_prefix, prop="energy", isolated_atom_info_key="config_type",
     isolated_atom_info_value="default"):
-    """ Calculates atomization energy. 
-    
+    """ Calculates atomization energy.
+
     Parameters
     ----------
     inputs: list[Atoms] or ConfigSet
         all configs, including isolated atoms
-    outputs: OutputSpec 
-        for saving structures with atomization energies 
+    outputs: OutputSpec
+        for saving structures with atomization energies
     prop_prefix: str
         prefix for reading total energy (e.g. Atoms.info[f"{prop_prefix}energy"])
-        and saving atomization energy (Atoms.info[f"{prop_prefix}atomization_energy"]) 
+        and saving atomization energy (Atoms.info[f"{prop_prefix}atomization_energy"])
     prop: str, default "energy"
         name for property to read from Atoms.info (Atoms.info["{prop_prefix}{prop}])
     isolated_atom_info_key: str, default "config_type"
@@ -86,8 +86,7 @@ def atomization_energy(inputs, outputs, prop_prefix, prop="energy", isolated_ato
         inputs=inputs,
         outputs=OutputSpec(),
         isolated_atom_info_key=isolated_atom_info_key,
-        isolated_atom_info_value=isolated_atom_info_value
-        )
+        isolated_atom_info_value=isolated_atom_info_value)
 
     isolated_at_data = {}
     for at in isolated_atoms:
@@ -95,11 +94,10 @@ def atomization_energy(inputs, outputs, prop_prefix, prop="energy", isolated_ato
     ref_present_elements = set(isolated_at_data.keys())
 
     configs_with_ae = wfl.map.map(
-        inputs = inputs, 
-        outputs = outputs, 
-        map_func = _get_single_ae,
-        args = [prop_prefix, isolated_at_data, ref_present_elements]
+        inputs=inputs,
+        outputs=outputs,
+        map_func=_get_single_ae,
+        args=[prop_prefix, isolated_at_data, ref_present_elements]
     )
 
     return configs_with_ae
-

--- a/wfl/utils/convex_hull.py
+++ b/wfl/utils/convex_hull.py
@@ -7,7 +7,7 @@ from scipy.spatial import ConvexHull
 # where N is index number, but gives seg fault
 def find_hull(ps, below=True):
     """find convex hull of set of points
-    
+
     Parameters
     ----------
     ps: ndarray(n_ps, n_dim)

--- a/wfl/utils/file_utils.py
+++ b/wfl/utils/file_utils.py
@@ -25,7 +25,7 @@ def clean_dir(directory, keep_files, force=False):
     # if the dir is non-existent
     if not os.path.isdir(directory):
         if force:
-            raise FileNotFoundError(f"No directory to be cleaned", directory)
+            raise FileNotFoundError(f"No directory to be cleaned {directory}")
         else:
             return
 

--- a/wfl/utils/julia.py
+++ b/wfl/utils/julia.py
@@ -1,7 +1,4 @@
 import os
-import subprocess
-import shlex
-from pathlib import Path
 
 def julia_exec_path():
     return os.environ.get("WFL_JULIA_COMMAND", "julia")

--- a/wfl/utils/parallel.py
+++ b/wfl/utils/parallel.py
@@ -2,7 +2,7 @@
 try:
     from ase.calculators.calculator import BaseCalculator, Calculator
     _calc_types = (BaseCalculator, Calculator)
-except:
+except ImportError:
     from ase.calculators.calculator import Calculator
     _calc_types = Calculator
 

--- a/wfl/utils/pressure.py
+++ b/wfl/utils/pressure.py
@@ -15,7 +15,7 @@ def sample_pressure(pressure, at=None):
             - float: used as pressure
             - ("info", dict_key): looks for dict_key in at.info, parsed same as pressure argument here
             - ("exponential", float): exponential distribution, rate=1. and scaled by float given
-            - ("normal_positive", mean, sigma): normal distribution with (mean, sigma) thrown away if negative value drawn, 
+            - ("normal_positive", mean, sigma): normal distribution with (mean, sigma) thrown away if negative value drawn,
               max 1000 tries
             - ("uniform", lower, upper): uniform distribution between bounds (lower, upper)
 

--- a/wfl/utils/quip_cli_strings.py
+++ b/wfl/utils/quip_cli_strings.py
@@ -29,7 +29,7 @@ def dict_to_quip_str(d, list_brackets='{}'):
         try:
             # try treating as an iterable
             return sep.join([str(vv) for vv in v])
-        except TypeError as exc:
+        except TypeError:
             return v
 
     string = ''

--- a/wfl/utils/version.py
+++ b/wfl/utils/version.py
@@ -10,7 +10,7 @@ def get_wfl_version():
                               "echo $(git describe --always --tags --dirty)",
                               shell=True, stdout=subprocess.PIPE) as gitv:
             version_str = gitv.stdout.read().strip().decode('utf-8')
-    except Exception as exc:
+    except Exception:
         version_str = ''
 
     if len(version_str.strip()) == 0:


### PR DESCRIPTION
Convert configs into a list before passing them through expyre back to fit, so they are actually sent to remote job. 

Add test of mace fit in a remote job. Required some massaging of env vars to allow pytorch-cpu to be loaded in remote job.

closes #269 