### PR TITLE
wait_for_results and fix multiple copies of output configs when interrupted and restarted

### DIFF
--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -178,7 +178,7 @@ jobs:
           echo "which pw.x"
           which pw.x
           ls -l /usr/bin/pw.x
-          export WFL_PYTEST_ASE_ESPRESSO_COMMAND=pw.x
+          export PYTEST_WFL_ASE_ESPRESSO_COMMAND=pw.x
 
       - name: Lint with flake8
         run: |

--- a/complete_pytest.tin
+++ b/complete_pytest.tin
@@ -4,6 +4,10 @@ module purge
 module load compiler/gnu python/system python_extras/quippy lapack/mkl
 module load python_extras/torch/cpu
 
+if [ -z "$WFL_PYTEST_EXPYRE_INFO" ]; then
+    echo "To override partition used, set WFL_PYTEST_EXPYRE_INFO='{"resources" : {"partitions": "DESIRED_PARTITION"}}'" 1>&2
+fi
+
 if [ ! -z $WFL_PYTHONPATH_EXTRA ]; then
     export PYTHONPATH=${WFL_PYTHONPATH_EXTRA}:${PYTHONPATH}
 fi

--- a/wfl/autoparallelize/base.py
+++ b/wfl/autoparallelize/base.py
@@ -182,7 +182,7 @@ def autoparallelize(func, *args, default_autopara_info={}, **kwargs):
 #
 # some ifs (int positional vs. str keyword) could be removed if we required that the iterable be passed into a kwarg.
 
-def _autoparallelize_ll(autopara_info, iterable, outputspec, op, *args, **kwargs):
+def _autoparallelize_ll(autopara_info, iterable, outputspec, op, *args, wait_for_results=True, **kwargs):
     """Parallelize some operation over an iterable
 
     Parameters
@@ -220,7 +220,7 @@ def _autoparallelize_ll(autopara_info, iterable, outputspec, op, *args, **kwargs
 
     if remote_info is not None:
         autopara_info.remote_info = remote_info
-        out = do_remotely(autopara_info, iterable, outputspec, op, args=args, kwargs=kwargs)
+        out = do_remotely(autopara_info, iterable, outputspec, op, args=args, kwargs=kwargs, wait_for_results=wait_for_results)
     else:
         out = do_in_pool(autopara_info.num_python_subprocesses, autopara_info.num_inputs_per_python_subprocess,
                          iterable, outputspec, op,

--- a/wfl/autoparallelize/remote.py
+++ b/wfl/autoparallelize/remote.py
@@ -11,7 +11,7 @@ from .pool import do_in_pool
 from expyre import ExPyRe, ExPyReJobDiedError
 
 
-def do_remotely(autopara_info, iterable=None, outputspec=None, op=None, args=[], kwargs={}, quiet=False):
+def do_remotely(autopara_info, iterable=None, outputspec=None, op=None, args=[], kwargs={}, quiet=False, wait_for_results=True):
     """run tasks as series of remote jobs
 
     Parameters
@@ -109,6 +109,9 @@ def do_remotely(autopara_info, iterable=None, outputspec=None, op=None, args=[],
             sys.stderr.write(f'Starting job for {xpr.id}\n')
         xpr.start(resources=remote_info.resources, system_name=remote_info.sys_name, header_extra=remote_info.header_extra,
                   exact_fit=remote_info.exact_fit, partial_node=remote_info.partial_node)
+
+    if not wait_for_results:
+        return None
 
     if remote_info.resubmit_killed_jobs:
         # need to loop over all jobs and get results with timeout 0, to look for all failures

--- a/wfl/calculators/espresso.py
+++ b/wfl/calculators/espresso.py
@@ -79,7 +79,9 @@ class Espresso(WFLFileIOCalculator, ASE_Espresso):
                     kwargs_command["profile"] = EspressoProfile(argv=argv)
                 except TypeError:
                     binary, parallel_info = parse_genericfileio_profile_argv(argv)
-                    kwargs_command["profile"] = EspressoProfile(binary=binary, pseudo_path=kwargs_command.pop("pseudo_dir"),
+                    # argument names keep changing (e.g. pseudo_path -> pseudo_dir), just pass first two as positional
+                    # and hope order doesn't change
+                    kwargs_command["profile"] = EspressoProfile(binary, kwargs_command.pop("pseudo_dir"),
                                                                 parallel_info=parallel_info)
 
         # WFLFileIOCalculator is a mixin, will call remaining superclass constructors for us

--- a/wfl/configset.py
+++ b/wfl/configset.py
@@ -404,6 +404,11 @@ class OutputSpec:
             if len(absolute_files) > 0 and self.file_root != Path(""):
                 raise ValueError(f"Got file_root {file_root} but files {absolute_files} are absolute paths")
             self.files = [Path(f) for f in self.files]
+
+            # wipe tmp files
+            for f in self.files:
+                tmp_f = self.file_root / f.parent / ("tmp." + f.name)
+                tmp_f.unlink(missing_ok=True)
         else:
             # store in memory
             self.configs = []


### PR DESCRIPTION
Add `wait_for_results` argument to normal autoparallelized ops (not just fitting) so many can be started without blocking.

Wipe tmp.* files when creating `OutputSpec` so current practice of opening them for append (mode "a") will not lead to multiple copies of initial configs if script is stopped mid-op and rerun.

closes #281 