### PR TITLE
MACE fit fix handling of path for foundations_model when workdir is used

### DIFF
--- a/wfl/fit/mace.py
+++ b/wfl/fit/mace.py
@@ -151,6 +151,9 @@ def fit(fitting_configs, mace_name, mace_fit_params, mace_fit_cmd=None, ref_prop
 
     fitting_configs_scratch_filename = _prep_configs_file(fitting_configs, mace_fit_params, "train_file")
 
+    if mace_fit_params.get("foundation_model", None) is not None and Path(mace_fit_params["foundation_model"]).is_file():
+        mace_fit_params["foundation_model"] = str(Path(mace_fit_params["foundation_model"]).absolute())
+
     for key, val in mace_fit_params.items():
         if isinstance(val, int) or isinstance(val, float):
             mace_fit_cmd += f" --{key}={val}"


### PR DESCRIPTION
Make `foundations_model` mace fit param an absolute path before it's passed to `run_train.py` if it appears to be a file so that it'll work after a possible `os.chdir` into an explicitly selected `workdir`.