### PR TITLE
Add yml file for pypi workflow, change dependencies to PyPI releases

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,0 +1,48 @@
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: publish to pypi
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.X"
+
+    - name: Install pypa/build
+      run: python3 -m pip install build --user
+    - name: Build a binary wheel and source tarball
+      run: python3 -m build
+    - name: Store distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/wfl
+    permissions:
+      id-token: write # for trusted publishing
+    steps:
+      - name: Download all dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+# could add signing into github release here

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,12 @@ import setuptools
 
 setuptools.setup(
     name="wfl",
-    version="0.2.4",
+    version="0.2.5",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     packages=setuptools.find_packages(exclude=["tests"]),
     install_requires=["click>=7.0", "numpy", "ase>=3.22.1", "pyyaml", "spglib", "docstring_parser",
-                      "expyre-wfl @ https://github.com/libAtoms/ExPyRe/tarball/main",
-                      "universalSOAP @ https://github.com/libAtoms/universalSOAP/tarball/main"],
+                      "expyre-wfl", "universalSOAP"],
     entry_points="""
     [console_scripts]
     wfl=wfl.cli.cli:cli

--- a/wfl/fit/error.py
+++ b/wfl/fit/error.py
@@ -5,7 +5,7 @@ import pandas as pd
 import numpy as np
 
 from matplotlib.figure import Figure
-from matplotlib.cm import get_cmap
+from matplotlib.pyplot import get_cmap
 
 
 def calc(inputs, calc_property_prefix, ref_property_prefix,


### PR DESCRIPTION
Hi, this pull-request adds the yml file for the PyPI distribution continuously integrated via Trusted Publisher Management, publishing is invoked by tags. Also the `setup.py` is modified with general dependencies from pypi for univeralSOAP and ExPyRe. Without adding the pull-requests in these repos first, I guess the pip install will fail.