### PR TITLE
CI test fails to import get_cmap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="wfl",
-    version="0.2.4",
+    version="0.2.5",
     packages=setuptools.find_packages(exclude=["tests"]),
     install_requires=["click>=7.0", "numpy", "ase>=3.22.1", "pyyaml", "spglib", "docstring_parser",
                       "expyre-wfl @ https://github.com/libAtoms/ExPyRe/tarball/main",

--- a/wfl/fit/error.py
+++ b/wfl/fit/error.py
@@ -5,7 +5,7 @@ import pandas as pd
 import numpy as np
 
 from matplotlib.figure import Figure
-from matplotlib.cm import get_cmap
+from matplotlib.pyplot import get_cmap
 
 
 def calc(inputs, calc_property_prefix, ref_property_prefix,


### PR DESCRIPTION
New location for `get_cmap`, in `matplotlib.pyplot` instead of `matplotlib.cm`