### PR TITLE
fix bug with remote jobs for an op that takes a ConfigSet as its input

### DIFF
--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -208,7 +208,12 @@ jobs:
           echo "SLURM apt-get done, doing local configuration"
           host_s=$( hostname -s )
           if [ -f /etc/slurm/slurm.conf ]; then sudo mv /etc/slurm/slurm.conf /etc/slurm/slurm.conf.orig; fi
-          sudo bash -c 'gzip -cd /usr/share/doc/slurmd/examples/slurm.conf.simple.gz > /etc/slurm/slurm.conf'
+          # /usr/share/doc/slurm-client/examples/slurm.conf.simple
+          # /usr/share/doc/slurmd/examples/slurm.conf.simple
+          # /usr/share/doc/slurmctld/examples/slurm.conf.simple
+          ## sudo bash -c 'gzip -cd /usr/share/doc/slurmd/examples/slurm.conf.simple.gz > /etc/slurm/slurm.conf'
+          sudo bash -c 'cp       /usr/share/doc/slurmd/examples/slurm.conf.simple /etc/slurm/slurm.conf'
+          ##
           # sudo sed -E -i -e "s/^\s*ClusterName\s*=.*/ClusterName=github_expyre_test/" /etc/slurm/slurm.conf
           sudo bash -c 'sed -E -i -e "s/^\s*SlurmctldHost\s*=.*/SlurmctldHost=_HOST_/" /etc/slurm/slurm.conf'
           # sudo sed -E -i -e "s/^\s*DefaultStorageHost\s*=.*/DefaultStorageHost=none" /etc/slurm/slurm.conf

--- a/tests/local_scripts/complete_pytest.tin
+++ b/tests/local_scripts/complete_pytest.tin
@@ -2,7 +2,7 @@
 
 module purge
 # module load compiler/gnu python/system python_extras/quippy lapack/mkl
-module load compiler/gnu python/conda python_extras/quippy/_2024-10-21 lapack/mkl
+module load compiler/gnu python python_extras/quippy lapack/mkl
 module load python_extras/torch/cpu
 
 if [ -z "$WFL_PYTEST_EXPYRE_INFO" ]; then

--- a/wfl/autoparallelize/remote.py
+++ b/wfl/autoparallelize/remote.py
@@ -84,6 +84,15 @@ def do_remotely(autopara_info, iterable=None, outputspec=None, op=None, rng=None
         if isinstance(iterable, ConfigSet):
             job_iterable = ConfigSet(item_list)
         else:
+            # for a subtle reason, passing an object with a loc to the remote function
+            # leads the remote do_in_pool to return a ConfigSet with empty containers
+            # for all earlier ConfigSet_loc, which confuses the code that processes the remote
+            # job results. If isinstance(item, Atoms), this info is remove automatically
+            # when item_list is turned into a ConfigSet (just above).  However, if item is a ConfigSet
+            # we must do this manually here
+            for item in item_list:
+                if isinstance(item, ConfigSet):
+                    item._enclosing_loc = ''
             job_iterable = item_list
         co = OutputSpec()
 


### PR DESCRIPTION
Fix _very_ subtle bug in remote jobs with an op that takes a `ConfigSet` as its basic input, rather than an `Atoms` object. 

The subtlety of this bug feels like a bad sign for the overall design, but the tiny fix suggests maybe it's OK

closes #349 