### PR TITLE
Updates to support numpy 2

### DIFF
--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -19,7 +19,6 @@ jobs:
     env:
       coverage-on-version: "3.10"
       use-mpi: True
-      PIP_CONSTRAINT: pip_constraint.txt
     defaults:
       run:
         shell: bash -l {0}
@@ -45,7 +44,6 @@ jobs:
 
       - name: Install latest ASE from pypi
         run: |
-          echo PIP_CONSTRAINT $PIP_CONSTRAINT
           # avoid broken extxyz writing (3.25, fixed in 3.26)
           # avoid broken optimizer.converged() (3.26) https://gitlab.com/ase/ase/-/issues/1744
           python3 -m pip install 'ase<3.25'
@@ -81,9 +79,6 @@ jobs:
                 exit 1
             fi
             source $mklvars intel64
-
-            # pip constraint needs to be an absolute filename
-            export PIP_CONSTRAINT=$PWD/$PIP_CONSTRAINT
 
             git clone https://github.com/phonopy/phonopy
             cd phonopy

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Install dependencies from pip
         run: |
-          echo "numpy<2" >> $PIP_CONSTRAINT
           python3 -m pip install wheel setuptools numpy scipy click matplotlib pyyaml spglib rdkit==2024.3.3 flake8 pytest pytest-cov requests
           python3 -c "import numpy; print('numpy version', numpy.__version__)"
 
@@ -103,14 +102,10 @@ jobs:
             python3 -m pip install quippy-ase
             python3 -c "import numpy; print('numpy version', numpy.__version__)"
 
-      - name: Install xTB (before things that need pandas like MACE and wfl, since it will break pandas-numpy compatibility by downgrading numpy)
+      - name: Install tblite
         run: |
-          # force compatible numpy version
-          conda install 'numpy<2'
-          conda install -c conda-forge xtb-python
+          conda install -c conda-forge tblite-python
           python3 -m pip install typing-extensions
-          # install pandas now to encourage compatible numpy version after conda regressed it
-          python3 -m pip install pandas
           python3 -c "import numpy; print('numpy version', numpy.__version__)"
 
       - name: MACE

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -276,6 +276,8 @@ jobs:
           mkdir $HOME/pytest_plain
           # attempt to work around mkl/numpy issue
           export MKL_THREADING_LAYER=GNU
+          # preload a newer libgomp needed by tblite; backwards compatible with torch
+          export LD_PRELOAD=$CONDA_PREFIX/lib/libgomp.so.1${LD_PRELOAD:+:$LD_PRELOAD}
           #
           export EXPYRE_PYTEST_SYSTEMS=github
           export WFL_PYTEST_BUILDCELL=$HOME/bin/buildcell
@@ -291,6 +293,8 @@ jobs:
           mkdir $HOME/pytest_cov
           # attempt to work around mkl/numpy issue
           export MKL_THREADING_LAYER=GNU
+          # preload a newer libgomp needed by tblite; backwards compatible with torch
+          export LD_PRELOAD=$CONDA_PREFIX/lib/libgomp.so.1${LD_PRELOAD:+:$LD_PRELOAD}
           #
           export EXPYRE_PYTEST_SYSTEMS=github
           export WFL_PYTEST_BUILDCELL=$HOME/bin/buildcell

--- a/docs/source/examples.daisy_chain_mlip_fitting.ipynb
+++ b/docs/source/examples.daisy_chain_mlip_fitting.ipynb
@@ -56,32 +56,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "\n",
-    "from ase import Atoms\n",
-    "\n",
-    "from xtb.ase.calculator import XTB\n",
-    "\n",
-    "from quippy.potential import Potential\n",
-    "\n",
-    "from wfl.configset import ConfigSet, OutputSpec\n",
-    "from wfl.generate import md\n",
-    "import wfl.descriptors.quippy\n",
-    "import wfl.select.by_descriptor\n",
-    "import wfl.fit.gap.simple\n",
-    "from wfl.calculators import generic\n",
-    "from wfl.autoparallelize import AutoparaInfo\n",
-    "from wfl.autoparallelize import RemoteInfo\n",
-    "from wfl.generate import smiles\n",
-    "from wfl.utils.configs import atomization_energy\n",
-    "from wfl.select.simple import by_bool_func\n",
-    "from wfl.fit import error\n",
-    "import wfl.map\n",
-    "from pathlib import Path\n",
-    "\n",
-    "from expyre.resources import Resources"
-   ]
+   "source": "import numpy as np\n\nfrom ase import Atoms\n\nfrom tblite.ase import TBLite\n\nfrom quippy.potential import Potential\n\nfrom wfl.configset import ConfigSet, OutputSpec\nfrom wfl.generate import md\nimport wfl.descriptors.quippy\nimport wfl.select.by_descriptor\nimport wfl.fit.gap.simple\nfrom wfl.calculators import generic\nfrom wfl.autoparallelize import AutoparaInfo\nfrom wfl.autoparallelize import RemoteInfo\nfrom wfl.generate import smiles\nfrom wfl.utils.configs import atomization_energy\nfrom wfl.select.simple import by_bool_func\nfrom wfl.fit import error\nimport wfl.map\nfrom pathlib import Path\n\nfrom expyre.resources import Resources"
   },
   {
    "cell_type": "code",
@@ -115,9 +90,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "xtb_calc = (XTB, [], {\"method\": \"GFN2-xTB\"})"
-   ]
+   "source": "xtb_calc = (TBLite, [], {\"method\": \"GFN2-xTB\"})"
   },
   {
    "cell_type": "markdown",

--- a/docs/source/examples.daisy_chain_mlip_fitting.ipynb
+++ b/docs/source/examples.daisy_chain_mlip_fitting.ipynb
@@ -23,65 +23,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Imports \n",
-    "\n",
-    "In addition to standard packages or wfl dependencies, we make use of three external packages: \n",
-    "\n",
-    "\n",
-    "- quip and quippy which provide interface for fitting and evaluating GAP. \n",
-    "  \n",
-    "  Documentation: https://pypi.org/project/quippy-ase/ \n",
-    "  \n",
-    "  Installation: `pip install quippy-ase`\n",
-    "\n",
-    "\n",
-    "- GFN2-xTB: a semi-empirical method designed for molecular systems, used as a reference method. \n",
-    "\n",
-    "  Documentation: \n",
-    "  - https://xtb-docs.readthedocs.io/en/latest/contents.html\n",
-    "  - https://xtb-python.readthedocs.io/en/latest/\n",
-    "\n",
-    "  Installation: `conda install -c conda-forge xtb-python`\n",
-    "\n",
-    "- RDKit: a chemoinformatics package that wfl uses to convert 2D SMILES strings (e.g. \"CCO\" for ethanol) into 3D `Atoms` objects. \n",
-    "\n",
-    "  Documentation: https://rdkit.org/\n",
-    "\n",
-    "  Installation: `conda install -c conda-forge rdkit`\n"
-   ]
+   "source": "## Imports \n\nIn addition to standard packages or wfl dependencies, we make use of three external packages: \n\n\n- quip and quippy which provide interface for fitting and evaluating GAP. \n  \n  Documentation: https://pypi.org/project/quippy-ase/ \n  \n  Installation: `pip install quippy-ase`\n\n\n- GFN2-xTB: a semi-empirical method designed for molecular systems, used as a reference method. We use the `tblite` implementation of GFN2-xTB. \n\n  Documentation: https://tblite.readthedocs.io/\n\n  Installation: `conda install -c conda-forge tblite-python`\n\n- RDKit: a chemoinformatics package that wfl uses to convert 2D SMILES strings (e.g. \"CCO\" for ethanol) into 3D `Atoms` objects. \n\n  Documentation: https://rdkit.org/\n\n  Installation: `conda install -c conda-forge rdkit`"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "\n",
-    "from ase import Atoms\n",
-    "\n",
-    "from xtb.ase.calculator import XTB\n",
-    "\n",
-    "from quippy.potential import Potential\n",
-    "\n",
-    "from wfl.configset import ConfigSet, OutputSpec\n",
-    "from wfl.generate import md\n",
-    "import wfl.descriptors.quippy\n",
-    "import wfl.select.by_descriptor\n",
-    "import wfl.fit.gap.simple\n",
-    "from wfl.calculators import generic\n",
-    "from wfl.autoparallelize import AutoparaInfo\n",
-    "from wfl.autoparallelize import RemoteInfo\n",
-    "from wfl.generate import smiles\n",
-    "from wfl.utils.configs import atomization_energy\n",
-    "from wfl.select.simple import by_bool_func\n",
-    "from wfl.fit import error\n",
-    "import wfl.map\n",
-    "from pathlib import Path\n",
-    "\n",
-    "from expyre.resources import Resources"
-   ]
+   "source": "import numpy as np\n\nfrom ase import Atoms\n\nfrom tblite.ase import TBLite\n\nfrom quippy.potential import Potential\n\nfrom wfl.configset import ConfigSet, OutputSpec\nfrom wfl.generate import md\nimport wfl.descriptors.quippy\nimport wfl.select.by_descriptor\nimport wfl.fit.gap.simple\nfrom wfl.calculators import generic\nfrom wfl.autoparallelize import AutoparaInfo\nfrom wfl.autoparallelize import RemoteInfo\nfrom wfl.generate import smiles\nfrom wfl.utils.configs import atomization_energy\nfrom wfl.select.simple import by_bool_func\nfrom wfl.fit import error\nimport wfl.map\nfrom pathlib import Path\n\nfrom expyre.resources import Resources"
   },
   {
    "cell_type": "code",
@@ -96,28 +45,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Reference calculator \n",
-    "\n",
-    "The calculator object given to `autoparalellize`-wrapped functions need to be pickle-able, so it can be executed on the parallel Python subprocesses with `multiprocessing.pool`. The calculators that can't be pickled need to be given to workflow functions as \n",
-    "\n",
-    "`(Initalizer, [args], {kwargs})`\n",
-    "\n",
-    "e.g. xtb would normally be called with \n",
-    "\n",
-    "`xtb_calc = XTB(method=\"GFN2-xTB\")`\n",
-    "\n",
-    "but instead in wfl scripts we define it as"
-   ]
+   "source": "## Reference calculator \n\nThe calculator object given to `autoparalellize`-wrapped functions need to be pickle-able, so it can be executed on the parallel Python subprocesses with `multiprocessing.pool`. The calculators that can't be pickled need to be given to workflow functions as \n\n`(Initalizer, [args], {kwargs})`\n\ne.g. GFN2-xTB would normally be called with \n\n`xtb_calc = TBLite(method=\"GFN2-xTB\")`\n\nbut instead in wfl scripts we define it as"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "xtb_calc = (XTB, [], {\"method\": \"GFN2-xTB\"})"
-   ]
+   "source": "xtb_calc = (TBLite, [], {\"method\": \"GFN2-xTB\"})"
   },
   {
    "cell_type": "markdown",

--- a/docs/source/examples.daisy_chain_mlip_fitting.ipynb
+++ b/docs/source/examples.daisy_chain_mlip_fitting.ipynb
@@ -23,14 +23,63 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Imports \n\nIn addition to standard packages or wfl dependencies, we make use of three external packages: \n\n\n- quip and quippy which provide interface for fitting and evaluating GAP. \n  \n  Documentation: https://pypi.org/project/quippy-ase/ \n  \n  Installation: `pip install quippy-ase`\n\n\n- GFN2-xTB: a semi-empirical method designed for molecular systems, used as a reference method. We use the `tblite` implementation of GFN2-xTB. \n\n  Documentation: https://tblite.readthedocs.io/\n\n  Installation: `conda install -c conda-forge tblite-python`\n\n- RDKit: a chemoinformatics package that wfl uses to convert 2D SMILES strings (e.g. \"CCO\" for ethanol) into 3D `Atoms` objects. \n\n  Documentation: https://rdkit.org/\n\n  Installation: `conda install -c conda-forge rdkit`"
+   "source": [
+    "## Imports \n",
+    "\n",
+    "In addition to standard packages or wfl dependencies, we make use of three external packages: \n",
+    "\n",
+    "\n",
+    "- quip and quippy which provide interface for fitting and evaluating GAP. \n",
+    "  \n",
+    "  Documentation: https://pypi.org/project/quippy-ase/ \n",
+    "  \n",
+    "  Installation: `pip install quippy-ase`\n",
+    "\n",
+    "\n",
+    "- GFN2-xTB: a semi-empirical method designed for molecular systems, used as a reference method. We use the `tblite` implementation of GFN2-xTB. \n",
+    "\n",
+    "  Documentation: https://tblite.readthedocs.io/\n",
+    "\n",
+    "  Installation: `conda install -c conda-forge tblite-python`\n",
+    "\n",
+    "- RDKit: a chemoinformatics package that wfl uses to convert 2D SMILES strings (e.g. \"CCO\" for ethanol) into 3D `Atoms` objects. \n",
+    "\n",
+    "  Documentation: https://rdkit.org/\n",
+    "\n",
+    "  Installation: `conda install -c conda-forge rdkit`"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import numpy as np\n\nfrom ase import Atoms\n\nfrom tblite.ase import TBLite\n\nfrom quippy.potential import Potential\n\nfrom wfl.configset import ConfigSet, OutputSpec\nfrom wfl.generate import md\nimport wfl.descriptors.quippy\nimport wfl.select.by_descriptor\nimport wfl.fit.gap.simple\nfrom wfl.calculators import generic\nfrom wfl.autoparallelize import AutoparaInfo\nfrom wfl.autoparallelize import RemoteInfo\nfrom wfl.generate import smiles\nfrom wfl.utils.configs import atomization_energy\nfrom wfl.select.simple import by_bool_func\nfrom wfl.fit import error\nimport wfl.map\nfrom pathlib import Path\n\nfrom expyre.resources import Resources"
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from ase import Atoms\n",
+    "\n",
+    "from tblite.ase import TBLite\n",
+    "\n",
+    "from quippy.potential import Potential\n",
+    "\n",
+    "from wfl.configset import ConfigSet, OutputSpec\n",
+    "from wfl.generate import md\n",
+    "import wfl.descriptors.quippy\n",
+    "import wfl.select.by_descriptor\n",
+    "import wfl.fit.gap.simple\n",
+    "from wfl.calculators import generic\n",
+    "from wfl.autoparallelize import AutoparaInfo\n",
+    "from wfl.autoparallelize import RemoteInfo\n",
+    "from wfl.generate import smiles\n",
+    "from wfl.utils.configs import atomization_energy\n",
+    "from wfl.select.simple import by_bool_func\n",
+    "from wfl.fit import error\n",
+    "import wfl.map\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from expyre.resources import Resources"
+   ]
   },
   {
    "cell_type": "code",
@@ -45,14 +94,28 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Reference calculator \n\nThe calculator object given to `autoparalellize`-wrapped functions need to be pickle-able, so it can be executed on the parallel Python subprocesses with `multiprocessing.pool`. The calculators that can't be pickled need to be given to workflow functions as \n\n`(Initalizer, [args], {kwargs})`\n\ne.g. GFN2-xTB would normally be called with \n\n`xtb_calc = TBLite(method=\"GFN2-xTB\")`\n\nbut instead in wfl scripts we define it as"
+   "source": [
+    "## Reference calculator \n",
+    "\n",
+    "The calculator object given to `autoparalellize`-wrapped functions need to be pickle-able, so it can be executed on the parallel Python subprocesses with `multiprocessing.pool`. The calculators that can't be pickled need to be given to workflow functions as \n",
+    "\n",
+    "`(Initalizer, [args], {kwargs})`\n",
+    "\n",
+    "e.g. GFN2-xTB would normally be called with \n",
+    "\n",
+    "`xtb_calc = TBLite(method=\"GFN2-xTB\")`\n",
+    "\n",
+    "but instead in wfl scripts we define it as"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "xtb_calc = (TBLite, [], {\"method\": \"GFN2-xTB\"})"
+   "source": [
+    "xtb_calc = (TBLite, [], {\"method\": \"GFN2-xTB\"})"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/docs/source/examples.index.md
+++ b/docs/source/examples.index.md
@@ -10,7 +10,7 @@ Examples often show examples of more than one thing. Below is a list of common o
 - EMT: 
     - [First example](first_example.md)
     - [Iterative GAP fitting ](examples.mlip_fitting.md)
-- XTB: 
+- GFN2-xTB: 
     - [Normal Modes of molecules](examples.normal_modes.md)
     - [Molecular Dynamics](examples.md.md)
     - [GAP fit workflow with many wfl use-case examples ](examples.daisy_chain_mlip_fitting.ipynb)

--- a/docs/source/examples.md.md
+++ b/docs/source/examples.md.md
@@ -4,7 +4,7 @@ The following script takes atomic structures from "configs.xyz", runs Berendsen 
 
 ```
 import os
-from xtb.ase.calculator import XTB
+from tblite.ase import TBLite
 from expyre.resources import Resources
 from wfl.autoparallelize import RemoteInfo
 from wfl.autoparallelize import AutoparaInfo
@@ -39,7 +39,7 @@ remote_info = RemoteInfo(
     pre_cmds = ["conda activate my-env"]
     ) 
 
-calc = (XTB, [], {'method':'GFN2-xTB'})
+calc = (TBLite, [], {'method':'GFN2-xTB'})
 
 ci = ConfigSet(input_fname)
 co = OutputSpec(out_fname)
@@ -49,7 +49,7 @@ co = OutputSpec(out_fname)
 # script would make it create and submit new jobs rather than monitor the ones already running.
 os.environ["WFL_DETERMINISTIC_HACK"] = "true"
 
-# xTB has some internal parallelisation that needs turning off by setting this env. variable. 
+# GFN2-xTB uses OpenMP internally, which clashes with the multiprocessing.pool parallelisation wfl uses, so turn it off.
 os.environ["OMP_NUM_THREADS"] = "1"
 
 ci = md.md(

--- a/docs/source/examples.normal_modes.md
+++ b/docs/source/examples.normal_modes.md
@@ -5,11 +5,11 @@ Workflow can numerically generate normal modes of a molecule with specified calc
 
 ## Generate
 
-The following script generates normal modes of methane and water with a [xTB](https://xtb-python.readthedocs.io/en/latest/index.html) calculator. The unit normal mode displacements are stored in `Atoms.arrays` and associated frequencies in `Atoms.info`. 
+The following script generates normal modes of methane and water with a [GFN2-xTB](https://tblite.readthedocs.io/) calculator. The unit normal mode displacements are stored in `Atoms.arrays` and associated frequencies in `Atoms.info`. 
 
 ```python
 from ase.build import molecule
-from xtb.ase.calculator import XTB
+from tblite.ase import TBLite
 from wfl.configset import ConfigSet, OutputSpec
 from wfl.generate import normal_modes as nm 
 
@@ -17,7 +17,7 @@ mols = [molecule("CH4"), molecule("H2O")]
 configset = ConfigSet(mols)
 outputspec = OutputSpec("molecules.normal_modes.xyz")
 
-calc = (XTB, [], {'method':'GFN2-xTB'})
+calc = (TBLite, [], {'method':'GFN2-xTB'})
 prop_prefix = 'xtb2_'
 
 nm.generate_normal_modes_parallel_hessian(inputs=configset,
@@ -34,7 +34,7 @@ To generate normal modes via finite differences, each of N atoms are displaced b
 
 ```python
 from ase.build import molecule
-from xtb.ase.calculator import XTB
+from tblite.ase import TBLite
 from wfl.configset import ConfigSet, OutputSpec
 from wfl.generate import normal_modes as nm 
 from wfl.autoparallelize import AutoparaInfo
@@ -43,7 +43,7 @@ mols = [molecule("CH4"), molecule("H2O")]
 configset = ConfigSet(mols)
 outputspec = OutputSpec("molecules.normal_modes.xyz")
 
-calc = (XTB, [], {'method':'GFN2-xTB'})
+calc = (TBLite, [], {'method':'GFN2-xTB'})
 prop_prefix = 'xtb2_'
 
 nm.generate_normal_modes_parallel_atoms(inputs=configset,

--- a/docs/source/examples.normal_modes.md
+++ b/docs/source/examples.normal_modes.md
@@ -9,7 +9,7 @@ The following script generates normal modes of methane and water with a [xTB](ht
 
 ```python
 from ase.build import molecule
-from xtb.ase.calculator import XTB
+from tblite.ase import TBLite
 from wfl.configset import ConfigSet, OutputSpec
 from wfl.generate import normal_modes as nm 
 
@@ -17,7 +17,7 @@ mols = [molecule("CH4"), molecule("H2O")]
 configset = ConfigSet(mols)
 outputspec = OutputSpec("molecules.normal_modes.xyz")
 
-calc = (XTB, [], {'method':'GFN2-xTB'})
+calc = (TBLite, [], {'method':'GFN2-xTB'})
 prop_prefix = 'xtb2_'
 
 nm.generate_normal_modes_parallel_hessian(inputs=configset,
@@ -34,7 +34,7 @@ To generate normal modes via finite differences, each of N atoms are displaced b
 
 ```python
 from ase.build import molecule
-from xtb.ase.calculator import XTB
+from tblite.ase import TBLite
 from wfl.configset import ConfigSet, OutputSpec
 from wfl.generate import normal_modes as nm 
 from wfl.autoparallelize import AutoparaInfo
@@ -43,7 +43,7 @@ mols = [molecule("CH4"), molecule("H2O")]
 configset = ConfigSet(mols)
 outputspec = OutputSpec("molecules.normal_modes.xyz")
 
-calc = (XTB, [], {'method':'GFN2-xTB'})
+calc = (TBLite, [], {'method':'GFN2-xTB'})
 prop_prefix = 'xtb2_'
 
 nm.generate_normal_modes_parallel_atoms(inputs=configset,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 name = "wfl"
 requires-python = ">=3.9"
-dependencies = [ "click>=7.0", "numpy<2", "ase>=3.22.1", "pyyaml", "spglib",
+dependencies = [ "click>=7.0", "numpy>=1.23", "ase>=3.22.1", "pyyaml", "spglib",
                  "docstring_parser", "expyre-wfl", "universalSOAP", "pandas" ]
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/conda-build/meta.yaml
+++ b/tests/conda-build/meta.yaml
@@ -22,7 +22,7 @@ requirements:
 
   run:
     - python
-    - numpy=1.19
+    - numpy>=1.23
     - ase
     - scipy
     - click

--- a/wfl/descriptor_heuristics.py
+++ b/wfl/descriptor_heuristics.py
@@ -50,6 +50,9 @@ def descriptors_from_length_scales(descriptors, Zs, length_scales, SOAP_hypers=N
     else:
         use_descriptors = descriptors
 
+    # cast away from np.int64 to plain ints; to work in GAP descriptor templates
+    Zs = [int(Z) for Z in Zs]
+
     repl_dict = {'BOND_LEN_MAX': max([length_scales[Z]['bond_len'][0] for Z in Zs])}
 
     dup = False

--- a/wfl/generate/md/__init__.py
+++ b/wfl/generate/md/__init__.py
@@ -5,6 +5,7 @@ import numpy as np
 from ase.md.nptberendsen import NPTBerendsen
 from ase.md.nvtberendsen import NVTBerendsen
 from ase.md.velocitydistribution import MaxwellBoltzmannDistribution, Stationary
+from ase.parallel import DummyMPI
 from ase.md.verlet import VelocityVerlet
 from ase.md.langevin import Langevin
 from ase.md.logger import MDLogger
@@ -149,7 +150,7 @@ def _sample_autopara_wrappable_single(at, at_i, calculator, steps, dt, logger_in
     if temperature_use is not None:
         # set initial temperature
         assert rng is not None
-        MaxwellBoltzmannDistribution(at, temperature_K=temperature_use[0]['T_i'], force_temp=True, comm=None, rng=rng)
+        MaxwellBoltzmannDistribution(at, temperature_K=temperature_use[0]['T_i'], force_temp=True, comm=DummyMPI, rng=rng)
         Stationary(at, preserve_temperature=True)
 
     stage_kwargs = {'timestep': dt * fs}

--- a/wfl/generate/md/__init__.py
+++ b/wfl/generate/md/__init__.py
@@ -149,7 +149,7 @@ def _sample_autopara_wrappable_single(at, at_i, calculator, steps, dt, logger_in
     if temperature_use is not None:
         # set initial temperature
         assert rng is not None
-        MaxwellBoltzmannDistribution(at, temperature_K=temperature_use[0]['T_i'], force_temp=True, communicator=None, rng=rng)
+        MaxwellBoltzmannDistribution(at, temperature_K=temperature_use[0]['T_i'], force_temp=True, comm=None, rng=rng)
         Stationary(at, preserve_temperature=True)
 
     stage_kwargs = {'timestep': dt * fs}

--- a/wfl/generate/md/__init__.py
+++ b/wfl/generate/md/__init__.py
@@ -150,7 +150,7 @@ def _sample_autopara_wrappable_single(at, at_i, calculator, steps, dt, logger_in
     if temperature_use is not None:
         # set initial temperature
         assert rng is not None
-        MaxwellBoltzmannDistribution(at, temperature_K=temperature_use[0]['T_i'], force_temp=True, comm=DummyMPI, rng=rng)
+        MaxwellBoltzmannDistribution(at, temperature_K=temperature_use[0]['T_i'], force_temp=True, comm=DummyMPI(), rng=rng)
         Stationary(at, preserve_temperature=True)
 
     stage_kwargs = {'timestep': dt * fs}

--- a/wfl/generate/md/__init__.py
+++ b/wfl/generate/md/__init__.py
@@ -149,7 +149,7 @@ def _sample_autopara_wrappable_single(at, at_i, calculator, steps, dt, logger_in
     if temperature_use is not None:
         # set initial temperature
         assert rng is not None
-        MaxwellBoltzmannDistribution(at, temperature_K=temperature_use[0]['T_i'], force_temp=True, communicator=None, rng=rng)
+        MaxwellBoltzmannDistribution(at, temperature_K=temperature_use[0]['T_i'], force_temp=True, rng=rng)
         Stationary(at, preserve_temperature=True)
 
     stage_kwargs = {'timestep': dt * fs}

--- a/wfl/generate/supercells.py
+++ b/wfl/generate/supercells.py
@@ -65,7 +65,7 @@ def _largest_isotropic_supercell(at, max_n_atoms, vary_cell_vectors=None):
         min_cell_i = np.argmin(np.linalg.norm(t_cell[vary_cell_vectors], axis=1))
         min_cell_i = vary_cell_vectors[min_cell_i]
         n_dups[min_cell_i] += 1
-        if np.product(n_dups) * len(at) > max_n_atoms:
+        if np.prod(n_dups) * len(at) > max_n_atoms:
             n_dups[min_cell_i] -= 1
             break
     return n_dups

--- a/wfl/select/flat_histogram.py
+++ b/wfl/select/flat_histogram.py
@@ -13,7 +13,7 @@ def _select_by_bin(weights, bin_edges, quantities, n, rng, kT=-1.0, replace=Fals
         raise ValueError("Not defined for non-positive n")
 
     if kT is None or kT <= 0:
-        kT = np.Infinity
+        kT = np.inf
 
     bin_centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])
     bin_centers -= bin_centers[0]

--- a/wfl/utils/ndim_neighbor_list.py
+++ b/wfl/utils/ndim_neighbor_list.py
@@ -133,7 +133,7 @@ def calc_list_cells(positions, ranges, Cartesian_distance=True):
 
     # First configs in pair.
     _first_at_neightuple_n = configs_in_bin_ba[:, config_pairs_pn[0]]
-    for i_offset in range(np.product(2 * neigh_search + 1)):
+    for i_offset in range(np.prod(2 * neigh_search + 1)):
         dD = []
         for i_dim in range(n_dims):
             dD.append(i_offset % (2 * neigh_search[i_dim] + 1))


### PR DESCRIPTION
Hi!

I'd like to lift the hard `numpy<2` cap, so that Workflow can be used with numpy2-only packages (e.g., [fhi-vibes](https://vibes-developers.gitlab.io/vibes/)). 

Small updates:
- Three calls switched to use numpy-2 syntax
- Changed project dependencies
- Switched the GFN2-xTB backend from the `xtb-python` package (legacy; restricts to numpy<2) to `tblite`

Once this PR is merged, would it also be possible to issue a new PyPi release?